### PR TITLE
Fix for display of 32bit pins and higher

### DIFF
--- a/Assets/Scripts/Game/Elements/DevPinInstance.cs
+++ b/Assets/Scripts/Game/Elements/DevPinInstance.cs
@@ -84,7 +84,7 @@ namespace DLS.Game
 
 			if (pinValueDisplayMode == PinValueDisplayMode.SignedDecimal)
 			{
-				displayValue = Maths.TwosComplement(rawValue, (int)BitCount);
+				displayValue = Maths.TwosComplement(rawValue, Math.Min((int)BitCount,32));
 			}
 
 			return displayValue;

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -220,13 +220,32 @@ namespace DLS.Graphics
 			Draw.Text(font, text, FontSizePinLabel, centre, Anchor.TextFirstLineCentre, Color.white);
 		}
 
+		static void CopyToCharBuffer(DevPinInstance pin, string text)
+		{
+			char[] chars = text.ToCharArray();
+			for (int i = 0; i < chars.Length; i++) {
+				pin.decimalDisplayCharBuffer[i] = chars[i];
+			}
+		}
 		public static void DrawPinDecValue(DevPinInstance pin)
 		{
 			if (pin.pinValueDisplayMode == PinValueDisplayMode.Off) return;
 
 			int charCount;
 
-			if (pin.pinValueDisplayMode != PinValueDisplayMode.HEX)
+			if (pin.Pin.State.IsValueBiggerThanInt() || (((pin.GetStateDecimalDisplayValue()&(1<<31)) == (1<<31)) && pin.pinValueDisplayMode!=PinValueDisplayMode.SignedDecimal) )
+			{
+				charCount = 7;
+				CopyToCharBuffer(pin, "TOO BIG");
+			}
+
+			else if (pin.GetStateDecimalDisplayValue() == int.MinValue)
+			{
+				charCount = 11;
+				CopyToCharBuffer(pin, "-2147483648");
+			}
+
+			else if (pin.pinValueDisplayMode != PinValueDisplayMode.HEX)
 			{
 				charCount = StringHelper.CreateIntegerStringNonAlloc(pin.decimalDisplayCharBuffer, pin.GetStateDecimalDisplayValue());
 			}
@@ -235,6 +254,8 @@ namespace DLS.Graphics
 			{
 				charCount = StringHelper.CreateHexStringNonAlloc(pin.decimalDisplayCharBuffer, pin.GetStateDecimalDisplayValue());
 			}
+
+			
 
 			FontType font = FontBold;
 			Bounds2D parentBounds = pin.BoundingBox;

--- a/Assets/Scripts/Simulation/PinStateValue.cs
+++ b/Assets/Scripts/Simulation/PinStateValue.cs
@@ -490,5 +490,13 @@ namespace DLS.Simulation
                  HandleBigMerge(sources);
             }
         }
+
+        public bool IsValueBiggerThanInt() {
+            if (size <= 32) { return false; }
+            for (int i = 33; i < BigValues.Length; i++) {
+                if (BigValues[i]) return true;
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
The game now reacts correctly instead of crashing when the 32th bit of a pin only is a activated while the signed value display is enabled.
Unsigned and HEX display capped at 31 bits.