### PR TITLE
Add language support

### DIFF
--- a/Assets/Build/DLS.unity
+++ b/Assets/Build/DLS.unity
@@ -241,7 +241,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   openSaveDirectory: 0
-  openInMainMenu: 0
+  openInMainMenu: 1
   testProjectName: MainTest
   openA: 1
   chipToOpenA: SPSTest

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1fc27224e65178c4290f17e938411150
+guid: 2ac592e82ffaf654190b55e155fd6e6c
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Resources/Language.json
+++ b/Assets/Resources/Language.json
@@ -1,0 +1,109 @@
+{
+    "keys": {
+        // Main Menu - Main Screen
+        "mainMenu.simTitle": {
+            "en-US": "DIGITAL LOGIC SIM"
+        },
+        "mainMenu.newProject": {
+            "en-US": "New Project"
+        },
+        "mainMenu.openProject": {
+            "en-US": "Open Project"
+        },
+            // Main Menu - Project Selection
+            "mainMenu.projectSelection.back": {
+                "en-US": "Back"
+            },
+            "mainMenu.projectSelection.delete": {
+                "en-US": "Delete"
+            },
+                "mainMenu.projectSelection.delete.contents": {
+                    "en-US": "Are you sure you want to delete this project?"
+                },
+            "mainMenu.projectSelection.duplicate": {
+                "en-US": "Duplicate"
+            },
+            "mainMenu.projectSelection.rename": {
+                "en-US": "Rename"
+            },
+            "mainMenu.projectSelection.open": {
+                "en-US": "Open"
+            },
+                // Main Menu - Project load errors
+                "mainMenu.projectSelection.open.incompatibleVersion": {
+                    "en-US": "This project requires version {0} or later." // {0}: Earliest project version
+                },
+                "mainMenu.projectSelection.open.unrecognizedProjectFormat": {
+                    "en-US": "Unrecognized project format"
+                },
+        "mainMenu.settings": {
+            "en-US": "Settings"
+        },
+            // Main Menu - Settings
+            "mainMenu.settings.resolution" : {
+                "en-US": "Resolution"
+            },
+            "mainMenu.settings.fullscreen" : {
+                "en-US": "Fullscreen"
+            },
+                // Main Menu - Fullscreen Options
+                "mainMenu.settings.fullscreen.off" : {
+                    "en-US": "OFF"
+                },
+                "mainMenu.settings.fullscreen.maximized" : {
+                    "en-US": "MAXIMIZED"
+                },
+                "mainMenu.settings.fullscreen.borderless" : {
+                    "en-US": "BORDERLESS"
+                },
+                "mainMenu.settings.fullscreen.exclusive" : {
+                    "en-US": "EXCLUSIVE"
+                },
+            "mainMenu.settings.vSync" : {
+                "en-US": "VSync"
+            },
+                // Main Menu - VSync On and Off
+                "mainMenu.settings.vSync.disabled" : {
+                    "en-US": "DISABLED"
+                },
+                "mainMenu.settings.vSync.enabled" : {
+                    "en-US": "ENABLED"
+                },
+            "mainMenu.settings.language" : {
+                "en-US": "Language"
+            },
+            "mainMenu.settings.exit": {
+                "en-US": "EXIT"
+            },
+            "mainMenu.settings.apply": {
+                "en-US": "APPLY"
+            },
+        "mainMenu.about": {
+            "en-US": "About"
+        },
+            // Main Menu - About contents
+            "mainMenu.about.contents": {
+                "en-US": "Todo: write something helpful here..."
+            },
+        "mainMenu.quit": {
+            "en-US": "Quit"
+        },
+        "mainMenu.createdBy": {
+            "en-US": "Created by: Sebastian Lague"
+        },
+        "mainMenu.version": {
+            "en-US": "Version: {0} ({1})" // {0}: Version, {1}: Date
+        },
+
+        // Generic - Cancel and Confirm buttons 
+        "generic.cancel": {
+            "en-US": "CANCEL"
+        },
+        "generic.confirm": {
+            "en-US": "CONFIRM"
+        }
+    },
+    "languages": [
+        {"name": "English", "code": "en-US"}
+    ]
+}

--- a/Assets/Resources/Language.json.meta
+++ b/Assets/Resources/Language.json.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: 1fc27224e65178c4290f17e938411150
-folderAsset: yes
-DefaultImporter:
+guid: 760ea391bc4085c44ba95fce3a706bc2
+TextScriptImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Description/Types/AppSettings.cs
+++ b/Assets/Scripts/Description/Types/AppSettings.cs
@@ -8,6 +8,7 @@ namespace DLS.Description
 		public int ResolutionY;
 		public FullScreenMode fullscreenMode;
 		public bool VSyncEnabled;
+		public string Language;
 
 		public static AppSettings Default() =>
 			new()
@@ -15,7 +16,8 @@ namespace DLS.Description
 				ResolutionX = 1920,
 				ResolutionY = 1080,
 				fullscreenMode = FullScreenMode.FullScreenWindow,
-				VSyncEnabled = true
+				VSyncEnabled = true,
+				Language = "en_us"
 			};
 	}
 }

--- a/Assets/Scripts/Editor.meta
+++ b/Assets/Scripts/Editor.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1fc27224e65178c4290f17e938411150
+guid: ae728704df2b06347993bb7e3ddad069
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Scripts/Editor/DLS.Editor.asmdef
+++ b/Assets/Scripts/Editor/DLS.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "DLS.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:06b859b54912bd449812ba95518ecd6b"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Editor/DLS.Editor.asmdef.meta
+++ b/Assets/Scripts/Editor/DLS.Editor.asmdef.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: 1fc27224e65178c4290f17e938411150
-folderAsset: yes
-DefaultImporter:
+guid: 0cc9f5bd6c9d26a4bbf23ec5e6da4de5
+AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Editor/LanguageRefresher.cs
+++ b/Assets/Scripts/Editor/LanguageRefresher.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using DLS.Game;
+using UnityEditor;
+
+namespace DLS.Editor
+{
+    // Allows instant refreshing of the language file.
+    public class LanguageRefresher : AssetPostprocessor
+    {
+        static string languageFilePath = "Assets/Resources/Language.json";
+        static void OnPostprocessAllAssets(
+            string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths
+        )
+        {
+            if (!EditorApplication.isPlaying) return;
+            if (importedAssets.Count() < 1) return;
+            if (importedAssets[0] == languageFilePath) Language.Refresh();
+        }
+    }
+}

--- a/Assets/Scripts/Editor/LanguageRefresher.cs.meta
+++ b/Assets/Scripts/Editor/LanguageRefresher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 506ab3ea15be3454db8401b7fa74fc79

--- a/Assets/Scripts/Game/Interaction/Language.cs
+++ b/Assets/Scripts/Game/Interaction/Language.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+
+namespace DLS.Game
+{
+    public static class Language
+    {
+        public static string[] Languages { get; private set; }
+        public static string[] LanguagesCode { get; private set; }
+        public static string currentLanguage = "en-US";
+        static JObject keys;
+        public static void Refresh()
+        {
+            JObject languageFile = JObject.Parse(Resources.Load<TextAsset>("Language").text);
+            JObject[] languages = ((JArray)languageFile["languages"]).ToObject<JObject[]>();
+            keys = (JObject)languageFile["keys"];
+            Languages = Array.ConvertAll(languages, e => e["name"].ToString());
+            LanguagesCode = Array.ConvertAll(languages, e => e["code"].ToString());
+        }
+        public static string GetKey(string key, string language) => (string)keys[key][language];
+        public static string GetKey(string key) => GetKey(key, currentLanguage);
+    }
+}

--- a/Assets/Scripts/Game/Interaction/Language.cs.meta
+++ b/Assets/Scripts/Game/Interaction/Language.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b38fb156e631f804eb824e1e5c0cfabe

--- a/Assets/Scripts/Game/Main/Main.cs
+++ b/Assets/Scripts/Game/Main/Main.cs
@@ -57,6 +57,7 @@ namespace DLS.Game
 			int height = newSettings.fullscreenMode is FullScreenMode.Windowed ? newSettings.ResolutionY : FullScreenResolution.y;
 			Screen.SetResolution(width, height, newSettings.fullscreenMode);
 			QualitySettings.vSyncCount = newSettings.VSyncEnabled ? 1 : 0;
+			Language.currentLanguage = newSettings.Language;
 		}
 
 		public static void LoadMainMenu()

--- a/Assets/Scripts/Game/Main/UnityMain.cs
+++ b/Assets/Scripts/Game/Main/UnityMain.cs
@@ -170,6 +170,7 @@ namespace DLS.Game
 		{
 			Simulator.Reset();
 			UIDrawer.Reset();
+			Language.Refresh();
 			InteractionState.Reset();
 			CameraController.Reset();
 			WorldDrawer.Reset();

--- a/Assets/Scripts/Graphics/UI/MenuHelper.cs
+++ b/Assets/Scripts/Graphics/UI/MenuHelper.cs
@@ -18,7 +18,7 @@ namespace DLS.Graphics
 			Confirm
 		}
 
-		static readonly string[] CancelConfirmButtonNames = { "CANCEL", "CONFIRM" };
+		static string[] CancelConfirmButtonNames => new[] { Language.GetKey("generic.cancel"), Language.GetKey("generic.confirm") };
 		static readonly bool[] CancelConfirmInteractableState = { true, true };
 
 		static readonly string[] ButtonGroupNames = { "A", "B", "C" };

--- a/Assets/Scripts/Graphics/UI/Menus/MainMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/MainMenu.cs
@@ -23,32 +23,36 @@ namespace DLS.Graphics
 		static readonly UIHandle ID_ProjectNameInput = new("MainMenu_ProjectNameInputField");
 		static readonly UIHandle ID_DisplayResolutionWheel = new("MainMenu_DisplayResolutionWheel");
 		static readonly UIHandle ID_FullscreenWheel = new("MainMenu_FullscreenWheel");
+		static readonly UIHandle ID_LanguageWheel = new("MainMenu_LanguageWheel");
 		static readonly UIHandle ID_ProjectsScrollView = new("MainMenu_ProjectsScrollView");
 
-		static readonly string[] SettingsWheelFullScreenOptions = { "OFF", "MAXIMIZED", "BORDERLESS", "EXCLUSIVE" };
+		static string[] SettingsWheelFullScreenOptions => new[] {
+			Language.GetKey("mainMenu.settings.fullscreen.off"),
+			Language.GetKey("mainMenu.settings.fullscreen.maximized"),
+			Language.GetKey("mainMenu.settings.fullscreen.borderless"),
+			Language.GetKey("mainMenu.settings.fullscreen.exclusive"),
+		};
 		static readonly FullScreenMode[] FullScreenModes = { FullScreenMode.Windowed, FullScreenMode.MaximizedWindow, FullScreenMode.FullScreenWindow, FullScreenMode.ExclusiveFullScreen };
-		static readonly string[] SettingsWheelVSyncOptions = { "DISABLED", "ENABLED" };
+		static string[] SettingsWheelVSyncOptions => new[] { Language.GetKey("mainMenu.settings.vSync.disabled"), Language.GetKey("mainMenu.settings.vSync.enabled") };
 
 		static readonly Func<string, bool> projectNameValidator = ProjectNameValidator;
 		static readonly UI.ScrollViewDrawContentFunc loadProjectScrollViewDrawer = DrawAllProjectsInScrollView;
 
 
-		static readonly string[] menuButtonNames =
-		{
-			FormatButtonString("New Project"),
-			FormatButtonString("Open Project"),
-			FormatButtonString("Settings"),
-			FormatButtonString("About"),
-			FormatButtonString("Quit")
+		static string[] menuButtonNames => new[] {
+			FormatButtonString(Language.GetKey("mainMenu.newProject")),
+			FormatButtonString(Language.GetKey("mainMenu.openProject")),
+			FormatButtonString(Language.GetKey("mainMenu.settings")),
+			FormatButtonString(Language.GetKey("mainMenu.about")),
+			FormatButtonString(Language.GetKey("mainMenu.quit"))
 		};
 
-		static readonly string[] openProjectButtonNames =
-		{
-			FormatButtonString("Back"),
-			FormatButtonString("Delete"),
-			FormatButtonString("Duplicate"),
-			FormatButtonString("Rename"),
-			FormatButtonString("Open")
+		static string[] openProjectButtonNames => new[] {
+			FormatButtonString(Language.GetKey("mainMenu.projectSelection.back")),
+			FormatButtonString(Language.GetKey("mainMenu.projectSelection.delete")),
+			FormatButtonString(Language.GetKey("mainMenu.projectSelection.duplicate")),
+			FormatButtonString(Language.GetKey("mainMenu.projectSelection.rename")),
+			FormatButtonString(Language.GetKey("mainMenu.projectSelection.open"))
 		};
 
 		static readonly Vector2Int[] Resolutions =
@@ -61,7 +65,7 @@ namespace DLS.Graphics
 
 		static readonly string[] ResolutionNames = Resolutions.Select(r => ResolutionToString(r)).ToArray();
 		static readonly string[] FullScreenResName = Resolutions.Select(r => ResolutionToString(Main.FullScreenResolution)).ToArray();
-		static readonly string[] settingsButtonGroupNames = { "EXIT", "APPLY" };
+		static string[] settingsButtonGroupNames => new[] { Language.GetKey("mainMenu.settings.exit"), Language.GetKey("mainMenu.settings.apply") };
 		static readonly bool[] settingsButtonGroupStates = new bool[settingsButtonGroupNames.Length];
 
 		static readonly bool[] openProjectButtonStates = new bool[openProjectButtonNames.Length];
@@ -72,8 +76,8 @@ namespace DLS.Graphics
 
 		static int selectedProjectIndex;
 
-		static readonly string authorString = "Created by: Sebastian Lague";
-		static readonly string versionString = $"Version: {Main.DLSVersion} ({Main.LastUpdatedString})";
+		static string authorString => Language.GetKey("mainMenu.createdBy");
+		static string versionString => string.Format(Language.GetKey("mainMenu.version"), Main.DLSVersion, Main.LastUpdatedString);
 		static string SelectedProjectName => allProjectDescriptions[selectedProjectIndex].ProjectName;
 
 		static string FormatButtonString(string s) => capitalize ? s.ToUpper() : s;
@@ -88,7 +92,7 @@ namespace DLS.Graphics
 			}
 
 			UI.DrawFullscreenPanel(ColHelper.MakeCol255(47, 47, 53));
-			const string title = "DIGITAL LOGIC SIM";
+			string title = Language.GetKey("mainMenu.simTitle");
 			const float titleFontSize = 11.5f;
 			const float titleHeight = 24;
 			const float shaddowOffset = -0.33f;
@@ -255,13 +259,13 @@ namespace DLS.Graphics
 
 				// In case project was made with a newer version of the sim, check if this version is able to open it
 				bool canOpen = currentVersion.ToInt() >= earliestCompatible.ToInt();
-				string failureReason = canOpen ? string.Empty : $"This project requires version {earliestCompatible} or later.";
+				string failureReason = canOpen ? string.Empty : string.Format(Language.GetKey("mainMenu.projectSelection.open.incompatibleVersion"), earliestCompatible);
 				return (canOpen, failureReason);
 			}
 			catch
 			{
 				Debug.Log("Incompatible project: " + projectDescription.ProjectName);
-				return (false, "Unrecognized project format");
+				return (false, Language.GetKey("mainMenu.projectSelection.open.unrecognizedProjectFormat"));
 			}
 		}
 
@@ -315,7 +319,7 @@ namespace DLS.Graphics
 
 				// -- Resolution --
 				bool resEnabled = EditedAppSettings.fullscreenMode == FullScreenMode.Windowed;
-				UI.DrawText("Resolution", theme.FontRegular, theme.FontSizeRegular, pos, Anchor.CentreLeft, Color.white);
+				UI.DrawText(Language.GetKey("mainMenu.settings.resolution"), theme.FontRegular, theme.FontSizeRegular, pos, Anchor.CentreLeft, Color.white);
 				string[] resNames = resEnabled ? ResolutionNames : FullScreenResName;
 				int resIndex = UI.WheelSelector(ID_DisplayResolutionWheel, resNames, new Vector2(elementOriginRight, pos.y), wheelSize, theme.OptionsWheel, Anchor.CentreRight, enabled: resEnabled);
 				EditedAppSettings.ResolutionX = Resolutions[resIndex].x;
@@ -323,15 +327,21 @@ namespace DLS.Graphics
 
 				// -- Full screen --
 				pos += Vector2.down * 4;
-				UI.DrawText("Fullscreen", theme.FontRegular, theme.FontSizeRegular, pos, Anchor.CentreLeft, Color.white);
+				UI.DrawText(Language.GetKey("mainMenu.settings.fullscreen"), theme.FontRegular, theme.FontSizeRegular, pos, Anchor.CentreLeft, Color.white);
 				int fullScreenSettingIndex = UI.WheelSelector(ID_FullscreenWheel, SettingsWheelFullScreenOptions, new Vector2(elementOriginRight, pos.y), wheelSize, theme.OptionsWheel, Anchor.CentreRight);
 				EditedAppSettings.fullscreenMode = FullScreenModes[fullScreenSettingIndex];
 				pos += Vector2.down * 4;
 
 				// -- Vsync --
-				UI.DrawText("VSync", theme.FontRegular, theme.FontSizeRegular, pos, Anchor.CentreLeft, Color.white);
+				UI.DrawText(Language.GetKey("mainMenu.settings.vSync"), theme.FontRegular, theme.FontSizeRegular, pos, Anchor.CentreLeft, Color.white);
 				int vsyncSetting = UI.WheelSelector(EditedAppSettings.VSyncEnabled ? 1 : 0, SettingsWheelVSyncOptions, new Vector2(elementOriginRight, pos.y), wheelSize, theme.OptionsWheel, Anchor.CentreRight);
 				EditedAppSettings.VSyncEnabled = vsyncSetting == 1;
+				pos += Vector2.down * 4;
+
+				// -- Vsync --
+				UI.DrawText(Language.GetKey("mainMenu.settings.language"), theme.FontRegular, theme.FontSizeRegular, pos, Anchor.CentreLeft, Color.white);
+				int languageSetting = UI.WheelSelector(ID_LanguageWheel, Language.Languages, new Vector2(elementOriginRight, pos.y), wheelSize, theme.OptionsWheel, Anchor.CentreRight);
+				EditedAppSettings.Language = Language.LanguagesCode[languageSetting];
 
 				// Background panel
 				UI.ModifyPanel(backgroundPanelID, UI.GetCurrentBoundsScope().Centre, UI.GetCurrentBoundsScope().Size + Vector2.one * 3, ColHelper.MakeCol255(37, 37, 43));
@@ -388,8 +398,8 @@ namespace DLS.Graphics
 				(Vector2 size, Vector2 centre) layoutCancel = UILayoutHelper.HorizontalLayout(2, 0, buttonsRegionCentre, buttonsRegionSize);
 				(Vector2 size, Vector2 centre) layoutConfirm = UILayoutHelper.HorizontalLayout(2, 1, buttonsRegionCentre, buttonsRegionSize);
 
-				bool cancelButton = UI.Button("CANCEL", theme.MainMenuButtonTheme, layoutCancel.centre, new Vector2(layoutCancel.size.x, 0), true, false, true);
-				bool confirmButton = UI.Button("CONFIRM", theme.MainMenuButtonTheme, layoutConfirm.centre, new Vector2(layoutConfirm.size.x, 0), canCreateProject, false, true);
+				bool cancelButton = UI.Button(Language.GetKey("generic.cancel"), theme.MainMenuButtonTheme, layoutCancel.centre, new Vector2(layoutCancel.size.x, 0), true, false, true);
+				bool confirmButton = UI.Button(Language.GetKey("generic.confirm"), theme.MainMenuButtonTheme, layoutConfirm.centre, new Vector2(layoutConfirm.size.x, 0), canCreateProject, false, true);
 
 				if (cancelButton || KeyboardShortcuts.CancelShortcutTriggered)
 				{
@@ -436,11 +446,11 @@ namespace DLS.Graphics
 			using (UI.BeginBoundsScope(true))
 			{
 				Draw.ID panelID = UI.ReservePanel();
-				UI.DrawText("Are you sure you want to delete this project?", theme.FontRegular, theme.FontSizeRegular, UI.Centre, Anchor.Centre, Color.yellow);
+				UI.DrawText(Language.GetKey("mainMenu.projectSelection.delete.contents"), theme.FontRegular, theme.FontSizeRegular, UI.Centre, Anchor.Centre, Color.yellow);
 
 				Vector2 buttonRegionTopLeft = UI.PrevBounds.BottomLeft + Vector2.down * DrawSettings.VerticalButtonSpacing;
 				float buttonRegionWidth = UI.PrevBounds.Width;
-				int buttonIndex = UI.HorizontalButtonGroup(new[] { "CANCEL", "DELETE" }, theme.MainMenuButtonTheme, buttonRegionTopLeft, buttonRegionWidth, DrawSettings.HorizontalButtonSpacing, 0, Anchor.TopLeft);
+				int buttonIndex = UI.HorizontalButtonGroup(new[] { Language.GetKey("generic.cancel"), Language.GetKey("mainMenu.projectSelection.delete").ToUpper() }, theme.MainMenuButtonTheme, buttonRegionTopLeft, buttonRegionWidth, DrawSettings.HorizontalButtonSpacing, 0, Anchor.TopLeft);
 				UI.ModifyPanel(panelID, UI.GetCurrentBoundsScope().Centre, UI.GetCurrentBoundsScope().Size + Vector2.one * 2, ColHelper.MakeCol255(37, 37, 43));
 
 				if (buttonIndex == 0) // Cancel
@@ -461,8 +471,8 @@ namespace DLS.Graphics
 		{
 			ButtonTheme theme = DrawSettings.ActiveUITheme.MainMenuButtonTheme;
 
-			UI.DrawText("Todo: write something helpful here...", theme.font, theme.fontSize, UI.Centre, Anchor.Centre, Color.white);
-			if (UI.Button("Back", theme, UI.CentreBottom + Vector2.up * 22, Vector2.zero, true, true, true))
+			UI.DrawText(Language.GetKey("mainMenu.about.contents"), theme.font, theme.fontSize, UI.Centre, Anchor.Centre, Color.white);
+			if (UI.Button(Language.GetKey("mainMenu.projectSelection.back"), theme, UI.CentreBottom + Vector2.up * 22, Vector2.zero, true, true, true))
 			{
 				BackToMain();
 			}

--- a/Assets/Scripts/Simulation/PinStateValue.cs
+++ b/Assets/Scripts/Simulation/PinStateValue.cs
@@ -116,7 +116,7 @@ namespace DLS.Simulation
 
         public void SetShortValue(ushort value)
         {
-            a = value| (a & 0xFFFF0000);
+            a = value | (a & 0xFFFF0000);
         }
 
         public void SetShortTristateAndValue(ushort tristate, ushort value)

--- a/TestData/AppSettings.json
+++ b/TestData/AppSettings.json
@@ -2,5 +2,6 @@
   "ResolutionX": 960,
   "ResolutionY": 540,
   "fullscreenMode": 3,
-  "VSyncEnabled": true
+  "VSyncEnabled": true,
+  "Language": "en-US"
 }

--- a/TestData/Projects/MainTest/ProjectDescription.json
+++ b/TestData/Projects/MainTest/ProjectDescription.json
@@ -3,20 +3,20 @@
   "DLSVersion_LastSaved": "2.1.6",
   "DLSVersion_EarliestCompatible": "2.0.0",
   "DLSVersion_LastSavedModdedVersion": "1.1.1",
-  "CreationTime": "2025-03-14T18:23:30.404+01:00",
-  "LastSaveTime": "2025-06-19T16:58:18.880+02:00",
+  "CreationTime": "2025-03-15T00:23:30.404+07:00",
+  "LastSaveTime": "2025-06-24T08:17:19.522+07:00",
   "Prefs_MainPinNamesDisplayMode": 2,
   "Prefs_ChipPinNamesDisplayMode": 1,
-  "Prefs_GridDisplayMode": 1,
+  "Prefs_GridDisplayMode": 0,
   "Prefs_Snapping": 0,
   "Prefs_StraightWires": 0,
   "Prefs_SimPaused": false,
   "Prefs_SimTargetStepsPerSecond": 15,
   "Prefs_SimStepsPerClockTick": 6,
   "Perfs_PinIndicators": 4,
-  "StepsRanSinceCreated": 105863230,
+  "StepsRanSinceCreated": 105864957,
   "TimeSpentSinceCreated": {
-    "StartFrom": "02:50:15.0946759"
+    "StartFrom": "02:52:57.2157514"
   },
   "AllCustomChipNames":[
     "AND",

--- a/TestData/Projects/MainTest/ProjectDescription.json
+++ b/TestData/Projects/MainTest/ProjectDescription.json
@@ -3,8 +3,8 @@
   "DLSVersion_LastSaved": "2.1.6",
   "DLSVersion_EarliestCompatible": "2.0.0",
   "DLSVersion_LastSavedModdedVersion": "1.1.1",
-  "CreationTime": "2025-03-14T18:23:30.404+01:00",
-  "LastSaveTime": "2025-06-18T15:29:44.388+02:00",
+  "CreationTime": "2025-03-15T00:23:30.404+07:00",
+  "LastSaveTime": "2025-06-19T13:28:30.616+07:00",
   "Prefs_MainPinNamesDisplayMode": 2,
   "Prefs_ChipPinNamesDisplayMode": 1,
   "Prefs_GridDisplayMode": 1,
@@ -14,9 +14,9 @@
   "Prefs_SimTargetStepsPerSecond": 15,
   "Prefs_SimStepsPerClockTick": 6,
   "Perfs_PinIndicators": 4,
-  "StepsRanSinceCreated": 105855705,
+  "StepsRanSinceCreated": 105856396,
   "TimeSpentSinceCreated": {
-    "StartFrom": "02:41:51.9372009"
+    "StartFrom": "02:42:38.0701642"
   },
   "AllCustomChipNames":[
     "AND",
@@ -77,9 +77,7 @@
     "BUTTON_test",
     "BUTTON_test2",
     "4sw",
-    "ConstTest",
-    "_",
-    "IndicatorTest"
+    "ConstTest"
   ],
   "StarredList":[
     {
@@ -112,14 +110,6 @@
     },
     {
       "Name":"BuzzTest",
-      "IsCollection":false
-    },
-    {
-      "Name":"_",
-      "IsCollection":false
-    },
-    {
-      "Name":"IndicatorTest",
       "IsCollection":false
     }
   ],


### PR DESCRIPTION
This PR adds the language feature. It allows accessing keys, which can be from a language, and they point to a file called Language.json in the Resources folder. It also allows instant refreshing of the keys, as soon as the language JSON is updated, via an editor script called LanguageRefresher.cs.

This PR only adds the feature, and not any other languages. The only language is English.