### PR TITLE
Optimization and Bug Fixes For The New Cache Mechanism

### DIFF
--- a/Assets/Scripts/Game/Project/DevChipInstance.cs
+++ b/Assets/Scripts/Game/Project/DevChipInstance.cs
@@ -215,8 +215,7 @@ namespace DLS.Game
 
 			RegenerateParentChipNamesHash();
 
-			Simulator.combinationalChipCaches.Remove(savedDescription.Name);
-			Simulator.chipsKnowToNotBeCombinational.Remove(savedDescription.Name);
+			SimChip.combinationalChipCaches.Remove(savedDescription.Name);
 		}
 
 		public void AddNewSubChip(SubChipInstance subChip, bool isLoading)

--- a/Assets/Scripts/Game/Project/Project.cs
+++ b/Assets/Scripts/Game/Project/Project.cs
@@ -276,6 +276,8 @@ namespace DLS.Game
 			chipViewStack.Clear();
 			chipViewStack.Push(devChip);
 			viewedChipsString = string.Empty;
+			Simulator.isCreatingACache = false;
+			Simulator.disabledCacheFrame = Simulator.simulationFrame;
 
 			if (devChip.LastSavedDescription != null)
 			{

--- a/Assets/Scripts/Game/Project/Project.cs
+++ b/Assets/Scripts/Game/Project/Project.cs
@@ -129,7 +129,7 @@ namespace DLS.Game
 			if (chipLibrary.TryGetChipDescription(subchip.Description.Name, out ChipDescription description))
 			{
 				Simulator.useCaching = false; // Disable caching while viewing so subchips actually show what they are doing
-				Simulator.isCreatingACache = false; // Cancel any cache creation that might be going on
+				SimChip.AbortCache(); // Cancel any cache creation that might be going on
 
 				SimChip simChipToView = ViewedChip.SimChip.GetSubChipFromID(subchip.ID);
 
@@ -277,8 +277,7 @@ namespace DLS.Game
 			chipViewStack.Clear();
 			chipViewStack.Push(devChip);
 			viewedChipsString = string.Empty;
-			Simulator.isCreatingACache = false;
-			Simulator.disabledCacheFrame = Simulator.simulationFrame;
+			SimChip.AbortCache();
 
 			if (devChip.LastSavedDescription != null)
 			{

--- a/Assets/Scripts/Graphics/UI/Menus/ChipCustomizationMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ChipCustomizationMenu.cs
@@ -130,11 +130,11 @@ namespace DLS.Graphics
 			if (chip.IsCombinational())
 			{
 				int numberOfInputBits = chip.CalculateNumberOfInputBits();
-				if (numberOfInputBits <= Simulator.MAX_NUM_INPUT_BITS_WHEN_AUTO_CACHING)
+				if (numberOfInputBits <= SimChip.MAX_NUM_INPUT_BITS_WHEN_AUTO_CACHING)
 				{
 					UI.DrawText("This chip is being cached.", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
 				}
-				else if (numberOfInputBits <= Simulator.MAX_NUM_INPUT_BITS_WHEN_USER_CACHING)
+				else if (numberOfInputBits <= SimChip.MAX_NUM_INPUT_BITS_WHEN_USER_CACHING)
 				{
 					int shouldBeCachedNum = UI.WheelSelector(ID_CachingOptions, cachingOptions, NextPos(), new Vector2(pw, DrawSettings.ButtonHeight), theme.OptionsWheel, Anchor.TopLeft);
 					bool shouldBeCached = false;

--- a/Assets/Scripts/Graphics/UI/Menus/CreateCacheUI.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/CreateCacheUI.cs
@@ -10,8 +10,8 @@ namespace DLS.Graphics
 	{
 		public static void DrawCreatingCacheInfo()
 		{
-			string chipName = Simulator.nameOfChipWhoseCacheIsBeingCreated;
-			int percentage = (int)(Simulator.cacheCreatingProgress * 100);
+			string chipName = SimChip.nameOfChipWhoseCacheIsBeingCreated;
+			int percentage = (int)(SimChip.cacheCreatingProgress * 100);
 			string text = $"Creating Cache ({percentage}%): {chipName}";
 			Vector2 textSize = UI.CalculateTextSize(text, UIThemeLibrary.FontSizeDefault, UIThemeLibrary.DefaultFont);
 			UI.TextWithBackground(new Vector2(BottomBarUI.buttonSpacing, BottomBarUI.barHeight + BottomBarUI.buttonSpacing), new Vector2(textSize.x + 1, textSize.y + 1), Anchor.BottomLeft, text, UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeDefault, Color.yellow, ColHelper.MakeCol255(40));

--- a/Assets/Scripts/Graphics/UI/UIDrawer.cs
+++ b/Assets/Scripts/Graphics/UI/UIDrawer.cs
@@ -86,11 +86,12 @@ namespace DLS.Graphics
 				bool showSimPausedBanner = project.simPaused;
 				if (showSimPausedBanner) SimPausedUI.DrawPausedBanner();
 				if (project.chipViewStack.Count > 1) ViewedChipsBar.DrawViewedChipsBanner(project, showSimPausedBanner);
-				if (Simulator.isCreatingACache) CreateCacheUI.DrawCreatingCacheInfo();
+				if (SimChip.isCreatingACache) CreateCacheUI.DrawCreatingCacheInfo();
 				aMenuIsOpen = false;
 			}
-
-			if (aMenuIsOpen) Simulator.isCreatingACache = false; // Cancel current caching process when a menu gets opened
+			// Cancel current caching process when a menu gets opened
+			if(aMenuIsOpen)
+				SimChip.AbortCache();
 
 			ContextMenu.Update();
 		}

--- a/Assets/Scripts/SaveSystem/Loader.cs
+++ b/Assets/Scripts/SaveSystem/Loader.cs
@@ -28,8 +28,7 @@ namespace DLS.SaveSystem
 			if (projectDescription.TimeSpentSinceCreated == null) projectDescription.TimeSpentSinceCreated = new();
 			ChipLibrary chipLibrary = LoadChipLibrary(projectDescription);
 
-			Simulator.combinationalChipCaches.Clear();
-			Simulator.chipsKnowToNotBeCombinational.Clear();
+			SimChip.combinationalChipCaches.Clear();
 
 			return new Project(projectDescription, chipLibrary);
 		}

--- a/Assets/Scripts/Simulation/Simulator.cs
+++ b/Assets/Scripts/Simulation/Simulator.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using UnityEngine;
 using DLS.Description;
 using DLS.Game;
 using NUnit.Framework.Interfaces;
@@ -32,11 +31,13 @@ namespace DLS.Simulation
 
 		// Small, purely combinational chips use a LUT for fast calculations. These are stored here. Maps the name of a chip to its LUT.
 		public static readonly Dictionary<string, uint[][]> combinationalChipCaches = new();
+		public static readonly Dictionary<string, int> chipLastCacheFrame = new();
 		public static readonly HashSet<string> chipsKnowToNotBeCombinational = new();
 		public static bool useCaching = true;
 
 		// Variables for the creating cache info popup
 		public static bool isCreatingACache = false;
+		public static int disabledCacheFrame = -1;
 		public static string nameOfChipWhoseCacheIsBeingCreated;
 		public static float cacheCreatingProgress;
 
@@ -140,8 +141,10 @@ namespace DLS.Simulation
 		}
 
 		// Recursively propagate signals through this chip and its subchips
-		static void StepChip(SimChip chip)
+		public static void StepChip(SimChip chip)
 		{
+			if(isCreatingACache)
+				chip.ResetReceivedFlagsOnChildrensPins();
 			// Propagate signal from all input dev-pins to all their connected pins
 			chip.Sim_PropagateInputs();
 
@@ -154,7 +157,7 @@ namespace DLS.Simulation
 				// Here two chips may be swapped if they are not 'ready' (i.e. all inputs have not yet been received for this
 				// frame; indicating that the input relies on the output). The purpose of this reordering is to allow some variety in
 				// the outcomes of race-conditions (such as an SR latch having both inputs enabled, and then released).
-				if (canDynamicReorderThisFrame && i > 0 && !nextSubChip.Sim_IsReady() && RandomBool())
+				if (!isCreatingACache && canDynamicReorderThisFrame && i > 0 && !nextSubChip.Sim_IsReady() && RandomBool())
 				{
 					SimChip potentialSwapChip = chip.SubChips[i - 1];
 					if (!ChipTypeHelper.IsBusOriginType(potentialSwapChip.ChipType))
@@ -168,17 +171,7 @@ namespace DLS.Simulation
 				{
 					ProcessBuiltinChip(nextSubChip); // We've reached a built-in chip, so process it directly
 				}
-				else if (combinationalChipCaches.ContainsKey(nextSubChip.Name) && useCaching)
-				{
-					bool wasSuccessful = ProcessCachedChip(nextSubChip); // We found a cached chip, so use LUT to process it directly
-					if (!wasSuccessful) StepChip(nextSubChip); // Fallback to normal simulation, if lookup failed
-				}
-				else if (!chipsKnowToNotBeCombinational.Contains(nextSubChip.Name) && useCaching)
-				{
-					RecalculateCachedLUTs(nextSubChip); // We found a chip that isn't cached but might be cachable, so we try to cache it
-					StepChip(nextSubChip);
-				}
-				else
+				else if (!(useCaching && nextSubChip.TryProcessingFromCache()))
 				{
 					StepChip(nextSubChip); // Recursively process custom chip
 				}
@@ -218,81 +211,6 @@ namespace DLS.Simulation
 			}
 		}
 
-		// Recalculates the caches of this chip and and all of its subChips.
-		static void RecalculateCachedLUTs(SimChip chip)
-		{
-			// Skip this chip, if its cache status is already known
-			if (combinationalChipCaches.ContainsKey(chip.Name) || chipsKnowToNotBeCombinational.Contains(chip.Name)) return;
-
-			// Recalculate caches for the subChips of the passed chip recursively
-			foreach (SimChip subChip in chip.SubChips)
-			{
-				RecalculateCachedLUTs(subChip);
-			}
-
-			// Don't cache this chip, if it isn't cachable
-			if (chip.ChipType != ChipType.Custom
-				|| (!chip.shouldBeCached && chip.CalculateNumberOfInputBits() > MAX_NUM_INPUT_BITS_WHEN_AUTO_CACHING)
-				|| !chip.IsCombinational()
-				|| chip.CalculateBiggestPinWidth() > MAX_INPUT_WIDTH_WHEN_AUTO_CACHING
-				)
-			{
-				chipsKnowToNotBeCombinational.Add(chip.Name);
-				return;
-			}
-
-			nameOfChipWhoseCacheIsBeingCreated = chip.Name;
-			cacheCreatingProgress = 0;
-			isCreatingACache = true;
-
-			// Buffer current Input
-			uint[] bufferedInput = new uint[chip.InputPins.Length];
-			for (int i = 0; i < bufferedInput.Length; i++)
-			{
-				bufferedInput[i] = chip.InputPins[i].State.GetShort();
-			}
-
-			// Cache this chip
-			int numberOfPossibleInputs = 1 << chip.CalculateNumberOfInputBits();
-			uint[][] LUT = new uint[numberOfPossibleInputs][];
-			for (int input = 0; input < numberOfPossibleInputs; input++)
-			{
-				chip.ResetReceivedFlagsOnAllPins(); // Make sure the chip only recieves our new input
-				// Set all inputPins to their part of the input
-				int tempInput = input;
-				for (int i = 0; i < chip.InputPins.Length; i++)
-				{
-					uint mask = ((uint)1 << chip.InputPins[i].State.size) - 1;
-					chip.InputPins[i].State.SetShort((uint)(tempInput & mask));
-					tempInput >>= (int)chip.InputPins[i].State.size;
-				}
-				StepChip(chip); // Calculate Result
-
-				// Store output into cache
-				int numberOfOutputPins = chip.OutputPins.Length;
-				uint[] outputs = new uint[numberOfOutputPins];
-				for (int i = 0; i < numberOfOutputPins; i++)
-				{
-					outputs[i] = chip.OutputPins[i].State.GetShortValues();
-				}
-				LUT[input] = outputs;
-
-				cacheCreatingProgress = (float)input / numberOfPossibleInputs;
-				if (!isCreatingACache) return; // Cancel the caching, if something ordered the caching to be stopped
-			}
-			combinationalChipCaches[chip.Name] = LUT;
-
-			// Reload buffered Input
-			chip.ResetReceivedFlagsOnAllPins(); // Make sure the chip only recieves our new input
-			for (int i = 0; i < bufferedInput.Length; i++)
-			{
-				chip.InputPins[i].State.SetShort(bufferedInput[i]);
-			}
-			StepChip(chip); // make sure the outputs are also correct again
-
-			isCreatingACache = false;
-		}
-		
 		static int ChooseNextSubChip(SimChip[] subChips, int num)
 		{
 			bool noSubChipsReady = true;
@@ -343,25 +261,6 @@ namespace DLS.Simulation
 			uint result = ((pcg_rngState >> (int)((pcg_rngState >> 28) + 4)) ^ pcg_rngState) * 277803737;
 			result = (result >> 22) ^ result;
 			return result < uint.MaxValue / 2;
-		}
-
-		// Sets the output pins by using an LUT. Returns true if successful, false otherwise.
-		static bool ProcessCachedChip(SimChip chip)
-		{
-			int input = 0;
-			for (int i = chip.InputPins.Length - 1; i >= 0; i--)
-			{
-				if (chip.InputPins[i].State.GetShort() >> 16 != 0) return false; // Fails if at least one input is in TriState (as these are not cached)
-				input <<= (int)chip.InputPins[i].State.size;
-				input |= (int)chip.InputPins[i].State.GetShort();
-			}
-			uint[][] LUT = combinationalChipCaches[chip.Name];
-			uint[] outputs = LUT[input];
-			for (int i = 0; i < outputs.Length; i++)
-			{
-				chip.OutputPins[i].State.SetShort(outputs[i]);
-			}
-			return true;
 		}
 
 		static void ProcessBuiltinChip(SimChip chip)


### PR DESCRIPTION
These changes reduce the number of recursions the cache generator needs to take during the already expensive iteration of chips for every input value, speeding up the cache time significantly for complex chips. Additionally, chips no longer need to perform a dictionary lookup for every input, which offers a small but measurable performance improvement during both normal simulation and cache generation. I have also marked ROM chips as combinational, as caching chips which use them should be fine for the same reasoning that caching the CONST chip should be fine. While these chips have a state, they can not be changed from outside of a chip.

Additionally, the following bugs have been fixed:

- The cache was not aware of a chip's subchips being modified, producing inaccurate results until every chip using the modified chip was saved or the simulation was restarted. Now a chip being saved will cause every chip using it, directly or indirectly, to regenerate their caches the next time they are stepped.
- Tri-stated outputs were being saved in the cache as low outputs, producing inaccurate results. They are now saved correctly.
- Output pins larger than 16 bits were being cached, resulting in any pins past the 16th being tri-stated regardless of what its output should have been. Chips with outputs this large now refuse to cache.
- Opening a new chip would not cancel the current cache generation, resulting in the simulation continuing to cache chips that were no longer on screen and not processing the current devchip until it finished. The cache now stops until the next frame if a new chip is opened, and in turn will only cache the new devchip's subchips.
- The test to determine if a chip is combinational ignored loops where a chip was connected to itself, resulting in chips which did this being cached even though they can form a stateful circuit which the cache mechanism would then break. Chips with such loops now refuse to cache.