### PR TITLE
Moved all builtin chips to use the canCache property and updated all logic to match.

### DIFF
--- a/Assets/Scripts/Game/Project/BuiltinChipCreator.cs
+++ b/Assets/Scripts/Game/Project/BuiltinChipCreator.cs
@@ -190,7 +190,7 @@ namespace DLS.Game
 			float height = SubChipInstance.MinChipHeightForPins(inputPins, null);
 			Vector2 size = new(CalculateGridSnappedWidth(GridSize * 9), height);
 
-			return CreateBuiltinChipDescription(ChipType.Buzzer, size, col, inputPins, null, null);
+			return CreateBuiltinChipDescription(ChipType.Buzzer, size, col, inputPins, null, null, canBeCached: false);
 		}
 		static ChipDescription CreateSPSChip()
 		{
@@ -207,7 +207,7 @@ namespace DLS.Game
 			float height = SubChipInstance.MinChipHeightForPins(outputPins, null);
 			Vector2 size = new(CalculateGridSnappedWidth(GridSize * 9), height);
 
-			return CreateBuiltinChipDescription(ChipType.SPS, size, col, null, outputPins);
+			return CreateBuiltinChipDescription(ChipType.SPS, size, col, null, outputPins, canBeCached: false);
 		}
 
 		static ChipDescription CreateRTC()
@@ -222,7 +222,7 @@ namespace DLS.Game
 			float height = SubChipInstance.MinChipHeightForPins(outputPins, null);
 			Vector2 size = new(CalculateGridSnappedWidth(GridSize * 9), height);
 
-			return CreateBuiltinChipDescription(ChipType.RTC, size, col, null, outputPins);
+			return CreateBuiltinChipDescription(ChipType.RTC, size, col, null, outputPins, canBeCached: false);
 		}
 
 		static ChipDescription dev_CreateRAM_8()
@@ -240,7 +240,7 @@ namespace DLS.Game
 			PinDescription[] outputPins = { CreatePinDescription("OUT", 5, PinBitCount.Bit8) };
 			Vector2 size = new(GridSize * 10, SubChipInstance.MinChipHeightForPins(inputPins, outputPins));
 
-			return CreateBuiltinChipDescription(ChipType.dev_Ram_8Bit, size, col, inputPins, outputPins);
+			return CreateBuiltinChipDescription(ChipType.dev_Ram_8Bit, size, col, inputPins, outputPins, canBeCached: false);
 		}
 
 		static ChipDescription CreateROM_8()
@@ -281,7 +281,7 @@ namespace DLS.Game
             Color col = GetColor(new(0.25f, 0.35f, 0.5f));
             Vector2 size = new(GridSize * 12, SubChipInstance.MinChipHeightForPins(inputPins, outputPins));
 
-            return CreateBuiltinChipDescription(ChipType.EEPROM_256x16, size, col, inputPins, outputPins);
+            return CreateBuiltinChipDescription(ChipType.EEPROM_256x16, size, col, inputPins, outputPins, canBeCached: false);
         }
 
 		static ChipDescription CreateConstant_8()
@@ -386,7 +386,7 @@ namespace DLS.Game
 			Color col = GetColor(new(0.1f, 0.1f, 0.1f));
 			PinDescription[] outputPins = { CreatePinDescription("CLK", 0) };
 
-			return CreateBuiltinChipDescription(ChipType.Clock, size, col, null, outputPins);
+			return CreateBuiltinChipDescription(ChipType.Clock, size, col, null, outputPins, canBeCached: false);
 		}
 
 		static ChipDescription CreatePulse()
@@ -396,7 +396,7 @@ namespace DLS.Game
 			PinDescription[] inputPins = { CreatePinDescription("IN", 0) };
 			PinDescription[] outputPins = { CreatePinDescription("PULSE", 1) };
 
-			return CreateBuiltinChipDescription(ChipType.Pulse, size, col, inputPins, outputPins);
+			return CreateBuiltinChipDescription(ChipType.Pulse, size, col, inputPins, outputPins, canBeCached: false);
 		}
 
 		static ChipDescription CreateDisplay7Seg()
@@ -427,7 +427,7 @@ namespace DLS.Game
 					SubChipID = -1
 				}
 			};
-			return CreateBuiltinChipDescription(ChipType.SevenSegmentDisplay, size, col, inputPins, null, displays, NameDisplayLocation.Hidden);
+			return CreateBuiltinChipDescription(ChipType.SevenSegmentDisplay, size, col, inputPins, null, displays, NameDisplayLocation.Hidden, canBeCached: false);
 		}
 
 		static ChipDescription CreateDisplayRGB()
@@ -468,7 +468,7 @@ namespace DLS.Game
 				}
 			};
 
-			return CreateBuiltinChipDescription(ChipType.DisplayRGB, size, col, inputPins, outputPins, displays, NameDisplayLocation.Hidden);
+			return CreateBuiltinChipDescription(ChipType.DisplayRGB, size, col, inputPins, outputPins, displays, NameDisplayLocation.Hidden, canBeCached: false);
 		}
 
 		static ChipDescription CreateDisplayDot()
@@ -506,7 +506,7 @@ namespace DLS.Game
 				}
 			};
 
-			return CreateBuiltinChipDescription(ChipType.DisplayDot, size, col, inputPins, outputPins, displays, NameDisplayLocation.Hidden);
+			return CreateBuiltinChipDescription(ChipType.DisplayDot, size, col, inputPins, outputPins, displays, NameDisplayLocation.Hidden, canBeCached: false);
 		}
 
 		static Vector2 BusChipSize(PinBitCount bitCount)

--- a/Assets/Scripts/Graphics/UI/Menus/ChipCustomizationMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ChipCustomizationMenu.cs
@@ -129,44 +129,36 @@ namespace DLS.Graphics
 			SimChip chip = Project.ActiveProject.ViewedChip.SimChip;
 			if (chip.IsCombinational())
 			{
-				if (chip.canBeCached)
+				int numberOfInputBits = chip.CalculateNumberOfInputBits();
+				if (numberOfInputBits <= SimChip.MAX_NUM_INPUT_BITS_WHEN_AUTO_CACHING)
 				{
-					int numberOfInputBits = chip.CalculateNumberOfInputBits();
-					if (numberOfInputBits <= SimChip.MAX_NUM_INPUT_BITS_WHEN_AUTO_CACHING)
-					{
-						UI.DrawText("This chip is being cached.", UIThemeLibrary.DefaultFont,
-							UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
-					}
-					else if (numberOfInputBits <= SimChip.MAX_NUM_INPUT_BITS_WHEN_USER_CACHING)
-					{
-						int shouldBeCachedNum = UI.WheelSelector(ID_CachingOptions, cachingOptions, NextPos(),
-							new Vector2(pw, DrawSettings.ButtonHeight), theme.OptionsWheel, Anchor.TopLeft);
-						bool shouldBeCached = false;
-						if (shouldBeCachedNum == 1) shouldBeCached = true;
-						ChipSaveMenu.ActiveCustomizeDescription.ShouldBeCached = shouldBeCached;
-						UI.DrawText("WARNING: Caching chips with many", UIThemeLibrary.DefaultFont,
-							UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
-						UI.DrawText("input bits significantly", UIThemeLibrary.DefaultFont,
-							UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
-						UI.DrawText("increases the time required to", UIThemeLibrary.DefaultFont,
-							UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
-						UI.DrawText("create the cache and may also", UIThemeLibrary.DefaultFont,
-							UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
-						UI.DrawText("increase memory consumption!", UIThemeLibrary.DefaultFont,
-							UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
-					}
-					else
-					{
-						UI.DrawText("This chip has too many input", UIThemeLibrary.DefaultFont,
-							UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
-						UI.DrawText("bits to be cached.", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall,
-							NextPos(), Anchor.TopLeft, Color.white);
-					}
+					UI.DrawText("This chip is being cached.", UIThemeLibrary.DefaultFont,
+						UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+				}
+				else if (numberOfInputBits <= SimChip.MAX_NUM_INPUT_BITS_WHEN_USER_CACHING)
+				{
+					int shouldBeCachedNum = UI.WheelSelector(ID_CachingOptions, cachingOptions, NextPos(),
+						new Vector2(pw, DrawSettings.ButtonHeight), theme.OptionsWheel, Anchor.TopLeft);
+					bool shouldBeCached = false;
+					if (shouldBeCachedNum == 1) shouldBeCached = true;
+					ChipSaveMenu.ActiveCustomizeDescription.ShouldBeCached = shouldBeCached;
+					UI.DrawText("WARNING: Caching chips with many", UIThemeLibrary.DefaultFont,
+						UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("input bits significantly", UIThemeLibrary.DefaultFont,
+						UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("increases the time required to", UIThemeLibrary.DefaultFont,
+						UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("create the cache and may also", UIThemeLibrary.DefaultFont,
+						UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("increase memory consumption!", UIThemeLibrary.DefaultFont,
+						UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
 				}
 				else
 				{
-					UI.DrawText("One or more chips", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
-					UI.DrawText("can not be cached.", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("This chip has too many input", UIThemeLibrary.DefaultFont,
+						UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("bits to be cached.", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall,
+						NextPos(), Anchor.TopLeft, Color.white);
 				}
 			}
 			else

--- a/Assets/Scripts/Simulation/SimChip.cs
+++ b/Assets/Scripts/Simulation/SimChip.cs
@@ -132,31 +132,12 @@ namespace DLS.Simulation
 		// Returns true, when this chip is purely combinational / stateless. This is the case, when the outputs of this chip depend entirely on the inputs and on nothing else.
 		public bool IsCombinational()
 		{
-			// Handle built in chips
-			switch (ChipType)
-			{
-				case ChipType.Nand:
-				case ChipType.TriStateBuffer:
-				case ChipType.Detector:
-				case ChipType.Merge_Pin:
-				case ChipType.Split_Pin:
-				case ChipType.Constant_8Bit: // Not stateless, but state can't change inside sim.
-				case ChipType.Rom_256x16: // True for these as well.
-					return true;
-				case ChipType.Clock:
-				case ChipType.Pulse:
-				case ChipType.dev_Ram_8Bit:
-				case ChipType.SevenSegmentDisplay:
-				case ChipType.DisplayRGB:
-				case ChipType.DisplayDot:
-				case ChipType.DisplayLED:
-				case ChipType.Key:
-				case ChipType.Buzzer:
-				case ChipType.EEPROM_256x16:
-				case ChipType.RTC:
-				case ChipType.SPS:
-					return false;
-			}
+			// For builtin chips, they are combinational if they are not a
+			// special input/output and don't have a state that can change
+			// while being run. This must be determined by whoever is
+			// implementing the builtin chip and hard coded.
+			if(ChipType != ChipType.Custom)
+				return canBeCached;
 
 			// Chip isn't combinational, if any of the subChips inputPins has more than one connection
 			foreach (SimChip subChip in SubChips)


### PR DESCRIPTION
All builtin chips which are not combinational now specify this when their chip description is created. The simulation logic now uses this property to determine if a builtin chip is combinational or not, and if not this will block a custom chip using said builtin chip from caching. The UI logic was checking the simulation logic for whether or not a chip was combinational before, but an extra check was added for the canCache property to make the UI respect it when the simulation logic did not. This extra check is redundant (it would always evaluate to true) and has been reverted now that the simulation logic respects the canCache property.