### PR TITLE
Add ExternalROM chip (256x16) with folder-based .bin file loading

### DIFF
--- a/Assets/Scripts/Description/Helpers/ChipTypeHelper.cs
+++ b/Assets/Scripts/Description/Helpers/ChipTypeHelper.cs
@@ -21,6 +21,7 @@ namespace DLS.Description
 			{ ChipType.dev_Ram_8Bit, "RAM-8" },
 			{ ChipType.Rom_256x16, $"ROM 256{mulSymbol}16" },
             { ChipType.EEPROM_256x16, $"EEPROM 256{mulSymbol}16" },
+			{ ChipType.ExternalRom_256x16, $"EXT-ROM 256{mulSymbol}16" },
 
 			// ---- Displays -----
 			{ ChipType.DisplayRGB, "RGB DISPLAY" },

--- a/Assets/Scripts/Description/Types/SubTypes/ChipTypes.cs
+++ b/Assets/Scripts/Description/Types/SubTypes/ChipTypes.cs
@@ -15,6 +15,7 @@ namespace DLS.Description
 		dev_Ram_8Bit,
 		Rom_256x16,
 		EEPROM_256x16,
+		ExternalRom_256x16,
 
 		// ---- Displays ----
 		SevenSegmentDisplay,

--- a/Assets/Scripts/Game/Main/UnityMain.cs
+++ b/Assets/Scripts/Game/Main/UnityMain.cs
@@ -151,6 +151,14 @@ namespace DLS.Game
 			}
 		}
 
+		void OnApplicationFocus(bool hasFocus)
+		{
+			if (hasFocus)
+			{
+				Graphics.ExternalRomFileMenu.ReloadAllExternalRoms();
+			}
+		}
+
 		void OnDestroy()
 		{
 			if (Project.ActiveProject != null) Project.ActiveProject.NotifyExit();

--- a/Assets/Scripts/Game/Project/BuiltinChipCreator.cs
+++ b/Assets/Scripts/Game/Project/BuiltinChipCreator.cs
@@ -36,6 +36,7 @@ namespace DLS.Game
 				dev_CreateRAM_8(),
 				CreateROM_8(),
 				CreateEEPROM_8(),
+				CreateExternalROM(),
 
 				// ---- Merge / Split ----
 
@@ -284,6 +285,24 @@ namespace DLS.Game
 
             return CreateBuiltinChipDescription(ChipType.EEPROM_256x16, size, col, inputPins, outputPins, canBeCached: false);
         }
+
+		static ChipDescription CreateExternalROM()
+		{
+			PinDescription[] inputPins =
+			{
+				CreatePinDescription("ADDRESS", 0, PinBitCount.Bit8)
+			};
+			PinDescription[] outputPins =
+			{
+				CreatePinDescription("OUT B", 1, PinBitCount.Bit8),
+				CreatePinDescription("OUT A", 2, PinBitCount.Bit8)
+			};
+
+			Color col = GetColor(new(0.2f, 0.5f, 0.5f));
+			Vector2 size = new(GridSize * 12, SubChipInstance.MinChipHeightForPins(inputPins, outputPins));
+
+			return CreateBuiltinChipDescription(ChipType.ExternalRom_256x16, size, col, inputPins, outputPins);
+		}
 
 		static ChipDescription CreateConstant_8()
 		{

--- a/Assets/Scripts/Game/Project/BuiltinCollectionCreator.cs
+++ b/Assets/Scripts/Game/Project/BuiltinCollectionCreator.cs
@@ -63,6 +63,7 @@ namespace DLS.Game
 				CreateChipCollection("MEMORY",
 					ChipType.Rom_256x16,
 					ChipType.EEPROM_256x16,
+					ChipType.ExternalRom_256x16,
 					ChipType.dev_Ram_8Bit
 				)
 			};

--- a/Assets/Scripts/Graphics/UI/Menus/ContextMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ContextMenu.cs
@@ -88,6 +88,14 @@ namespace DLS.Graphics
 
 
 
+		static readonly MenuEntry[] entries_builtinExternalRomSubchip =
+		{
+			new(Format("LOAD FILE"), OpenExternalRomFileMenu, CanEditCurrentChip),
+			new(Format("OPEN ROM FOLDER"), OpenRomFolder, () => true),
+			labelChipEntry,
+			deleteEntry
+		};
+
         static readonly MenuEntry[] entries_subChipOutput = pinColEntries;
 
 		static readonly MenuEntry[] entries_inputDevPin = new[]
@@ -190,6 +198,7 @@ namespace DLS.Graphics
 						{
 							headerName = ChipTypeHelper.IsBusType(subChip.ChipType) ? "BUS" : subChip.Description.Name;
 							if (subChip.ChipType is ChipType.Key) activeContextMenuEntries = entries_builtinKeySubchip;
+							else if (subChip.ChipType is ChipType.ExternalRom_256x16) activeContextMenuEntries = entries_builtinExternalRomSubchip;
 							else if (ChipTypeHelper.IsRomType(subChip.ChipType)) activeContextMenuEntries = entries_builtinRomSubchip;
 							else if (subChip.ChipType is ChipType.Pulse) activeContextMenuEntries = entries_builtinPulseChip;
 							else if (ChipTypeHelper.IsBusType(subChip.ChipType)) activeContextMenuEntries = entries_builtinBus;
@@ -425,6 +434,17 @@ namespace DLS.Graphics
 		static void OpenPulseEditMenu() => UIDrawer.SetActiveMenu(UIDrawer.MenuType.PulseEdit);
 
 		static void OpenConstantEditMenu() => UIDrawer.SetActiveMenu(UIDrawer.MenuType.ConstantEdit);
+
+		static void OpenExternalRomFileMenu() => UIDrawer.SetActiveMenu(UIDrawer.MenuType.ExternalRomFileSelect);
+
+		static void OpenRomFolder()
+		{
+			string romFolderPath = System.IO.Path.Combine(DLS.SaveSystem.SavePaths.AllData, "ROM");
+			System.IO.Directory.CreateDirectory(romFolderPath);
+			string path = romFolderPath.Replace("\\", "/");
+			string url = "file://" + (path.StartsWith("/") ? path : "/" + path);
+			UnityEngine.Application.OpenURL(url);
+		}
 
 		static bool CanEditCurrentChip() => Project.ActiveProject.CanEditViewedChip;
 

--- a/Assets/Scripts/Graphics/UI/Menus/ExternalRomFileMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ExternalRomFileMenu.cs
@@ -1,0 +1,155 @@
+using System.IO;
+using DLS.Game;
+using DLS.SaveSystem;
+using Seb.Vis;
+using Seb.Vis.UI;
+using UnityEngine;
+
+namespace DLS.Graphics
+{
+	public static class ExternalRomFileMenu
+	{
+		static SubChipInstance romChip;
+		static string romFolderPath;
+		static string[] binFileNames;
+		static bool hasFiles;
+
+		static readonly UIHandle ID_FileSelector = new("ExternalRomFileSelect_FileWheel");
+
+		public static string RomFolderPath => Path.Combine(SavePaths.AllData, "ROM");
+
+		public static void OnMenuOpened()
+		{
+			romChip = (SubChipInstance)ContextMenu.interactionContext;
+			romFolderPath = RomFolderPath;
+			Directory.CreateDirectory(romFolderPath);
+
+			string[] filePaths = Directory.GetFiles(romFolderPath, "*.bin");
+			hasFiles = filePaths.Length > 0;
+
+			if (hasFiles)
+			{
+				binFileNames = new string[filePaths.Length];
+				for (int i = 0; i < filePaths.Length; i++)
+				{
+					binFileNames[i] = Path.GetFileName(filePaths[i]);
+				}
+
+				// Pre-select the currently loaded file if there is one
+				int preselect = 0;
+				if (!string.IsNullOrEmpty(romChip.Label))
+				{
+					for (int i = 0; i < binFileNames.Length; i++)
+					{
+						if (binFileNames[i] == romChip.Label)
+						{
+							preselect = i;
+							break;
+						}
+					}
+				}
+
+				UI.GetWheelSelectorState(ID_FileSelector).index = preselect;
+			}
+			else
+			{
+				binFileNames = new string[] { "No .bin files found" };
+			}
+		}
+
+		public static void DrawMenu()
+		{
+			MenuHelper.DrawBackgroundOverlay();
+			Draw.ID panelID = UI.ReservePanel();
+			DrawSettings.UIThemeDLS theme = DrawSettings.ActiveUITheme;
+
+			Vector2 pos = UI.Centre + Vector2.up * (UI.HalfHeight * 0.25f);
+
+			using (UI.BeginBoundsScope(true))
+			{
+				UI.DrawText("Load External ROM", theme.FontBold, theme.FontSizeRegular, pos, Anchor.TextCentre, Color.white * 0.9f);
+
+				Vector2 subtitlePos = UI.PrevBounds.CentreBottom + Vector2.down * 1.5f;
+				string subtitle = "Place .bin files in: " + romFolderPath;
+				UI.DrawText(subtitle, theme.FontRegular, theme.FontSizeRegular * 0.8f, subtitlePos, Anchor.TextCentre, Color.white * 0.5f);
+
+				Vector2 wheelPos = UI.PrevBounds.CentreBottom + Vector2.down * DrawSettings.VerticalButtonSpacing;
+				Vector2 wheelSize = new(UI.Width * 0.35f, DrawSettings.SelectorWheelHeight);
+				int selectedIndex = UI.WheelSelector(ID_FileSelector, binFileNames, wheelPos, wheelSize, MenuHelper.Theme.OptionsWheel, Anchor.CentreTop);
+
+				MenuHelper.CancelConfirmResult result = MenuHelper.DrawCancelConfirmButtons(UI.GetCurrentBoundsScope().BottomLeft, UI.GetCurrentBoundsScope().Width, true);
+				MenuHelper.DrawReservedMenuPanel(panelID, UI.GetCurrentBoundsScope());
+
+				if (result == MenuHelper.CancelConfirmResult.Cancel || KeyboardShortcuts.CancelShortcutTriggered())
+				{
+					UIDrawer.SetActiveMenu(UIDrawer.MenuType.None);
+				}
+				else if (result == MenuHelper.CancelConfirmResult.Confirm && hasFiles)
+				{
+					string selectedFileName = binFileNames[selectedIndex];
+					romChip.Label = selectedFileName;
+					LoadFileIntoChip(romChip, selectedFileName);
+					UIDrawer.SetActiveMenu(UIDrawer.MenuType.None);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Loads a .bin file from the ROM folder into the chip's InternalData.
+		/// </summary>
+		public static void LoadFileIntoChip(SubChipInstance chip, string fileName)
+		{
+			string filePath = Path.Combine(RomFolderPath, fileName);
+			if (!File.Exists(filePath)) return;
+
+			byte[] bytes = File.ReadAllBytes(filePath);
+
+			uint[] data = new uint[256];
+			int byteCount = Mathf.Min(bytes.Length, 512);
+
+			for (int i = 0; i < byteCount / 2; i++)
+			{
+				uint low = bytes[i * 2];
+				uint high = (i * 2 + 1 < byteCount) ? (uint)bytes[i * 2 + 1] : 0u;
+				data[i] = (high << 8) | low;
+			}
+
+			// Handle odd trailing byte
+			if (byteCount % 2 == 1)
+			{
+				int addr = byteCount / 2;
+				if (addr < 256)
+				{
+					data[addr] = bytes[byteCount - 1];
+				}
+			}
+
+			for (int i = 0; i < 256; i++)
+			{
+				chip.InternalData[i] = data[i];
+			}
+
+			Project.ActiveProject.NotifyRomContentsEdited(chip);
+		}
+
+		/// <summary>
+		/// Reloads all ExternalROM chips in the current view from their associated .bin files.
+		/// Called on window focus to pick up external file changes.
+		/// </summary>
+		public static void ReloadAllExternalRoms()
+		{
+			if (Project.ActiveProject == null) return;
+
+			DevChipInstance viewedChip = Project.ActiveProject.ViewedChip;
+			if (viewedChip == null) return;
+
+			foreach (SubChipInstance subChip in viewedChip.GetSubchips())
+			{
+				if (subChip.ChipType == DLS.Description.ChipType.ExternalRom_256x16 && !string.IsNullOrEmpty(subChip.Label))
+				{
+					LoadFileIntoChip(subChip, subChip.Label);
+				}
+			}
+		}
+	}
+}

--- a/Assets/Scripts/Graphics/UI/UIDrawer.cs
+++ b/Assets/Scripts/Graphics/UI/UIDrawer.cs
@@ -27,7 +27,8 @@ namespace DLS.Graphics
             UnsavedChanges,
 			Search,
 			ChipLabelPopup,
-			SpecialChipMaker
+			SpecialChipMaker,
+			ExternalRomFileSelect
 		}
 
 		static MenuType activeMenuOld;
@@ -81,6 +82,7 @@ namespace DLS.Graphics
 			else if (menuToDraw == MenuType.PulseEdit) PulseEditMenu.DrawMenu();
 			else if (menuToDraw == MenuType.ConstantEdit)  ConstantEditMenu.DrawMenu();
 			else if (menuToDraw == MenuType.SpecialChipMaker) SpecialChipMakerMenu.DrawMenu();
+			else if (menuToDraw == MenuType.ExternalRomFileSelect) ExternalRomFileMenu.DrawMenu();
 			else
 			{
 				bool showSimPausedBanner = project.simPaused;
@@ -119,6 +121,7 @@ namespace DLS.Graphics
 				else if (ActiveMenu == MenuType.ProjectStats) ProjectStatsMenu.OnMenuOpened();
                 else if (ActiveMenu == MenuType.ConstantEdit) ConstantEditMenu.OnMenuOpened();
 				else if (ActiveMenu == MenuType.SpecialChipMaker) SpecialChipMakerMenu.OnMenuOpened();
+				else if (ActiveMenu == MenuType.ExternalRomFileSelect) ExternalRomFileMenu.OnMenuOpened();
 
 
 				if (InInputBlockingMenu() && Project.ActiveProject != null && Project.ActiveProject.controller != null)

--- a/Assets/Scripts/SaveSystem/DescriptionCreator.cs
+++ b/Assets/Scripts/SaveSystem/DescriptionCreator.cs
@@ -138,6 +138,7 @@ namespace DLS.SaveSystem
 			return type switch
 			{
 				ChipType.Rom_256x16 => new uint[256], // ROM contents
+				ChipType.ExternalRom_256x16 => new uint[256], // External ROM contents
 				ChipType.EEPROM_256x16 => new uint[257], // EEPROM contents + Rising-Edge detection
 				ChipType.Key => new uint[] { (uint)KeyCode.K }, // Key binding
 				ChipType.Pulse => new uint[] { 50, 0, 0 }, // Pulse width, ticks remaining, input state old

--- a/Assets/Scripts/Simulation/Simulator.cs
+++ b/Assets/Scripts/Simulation/Simulator.cs
@@ -510,6 +510,18 @@ namespace DLS.Simulation
                     break;
 				}
 
+				case ChipType.ExternalRom_256x16:
+				{
+					const uint mask = 0x00ff;
+					uint address = chip.InputPins[0].State.GetShortValues();
+					uint data = chip.InternalState[address];
+
+					chip.OutputPins[0].State.SetShort((data>>8) & mask);
+					chip.OutputPins[1].State.SetShort(data & mask);
+
+					break;
+				}
+
 				case ChipType.EEPROM_256x16:
 				{
                     const uint mask = 0x00ff;


### PR DESCRIPTION
Adds a new built-in EXT-ROM 256x16 chip that loads data from .bin files placed in <save_data>/ROM/. Users select files via a wheel selector in the context menu. The chip automatically reloads from disk when the application regains focus, so external edits are reflected without manual re-importing.

I noticed similar games like Virtual Circuit Board and Turing Complete have assembly editors. Unfortunately I don't have the Unity skills to build an assembly editor but with help from Claude Code it was quite easy to add this chip and allow me to use a normal editor to write assembly (or whatever other data I want) for my circuits.