### PR TITLE
fix: upgrades from versions earlier than 1.1.1 

### DIFF
--- a/Assets/Scripts/SaveSystem/UpgradeHelper.cs
+++ b/Assets/Scripts/SaveSystem/UpgradeHelper.cs
@@ -73,8 +73,8 @@ namespace DLS.SaveSystem
 			if (isVersionEarlierThan_1_1_1)
 			{
 				projectDescription.DLSVersion_LastSavedModdedVersion = Main.DLSVersion_ModdedID.ToString();
-				projectDescription.pinBitCounts.Union(Project.PinBitCounts);
-				projectDescription.SplitMergePairs.Union(Project.SplitMergePairs);
+				projectDescription.pinBitCounts = projectDescription.pinBitCounts.Union(Project.PinBitCounts).ToList();
+				projectDescription.SplitMergePairs = projectDescription.SplitMergePairs.Union(Project.SplitMergePairs).ToList();
 			}
         }
 


### PR DESCRIPTION
Updates pinBitCounts and splitMergePairs properly, union() is a pure function.