### PR TITLE
Refactor pin drawing

### DIFF
--- a/Assets/Scripts/Graphics/DrawSettings.cs
+++ b/Assets/Scripts/Graphics/DrawSettings.cs
@@ -138,7 +138,8 @@ namespace DLS.Graphics
 					MakeCol255(153, 102, 51), // Depth 1
 					MakeCol255(255, 0, 0), // Depth 2
 					MakeCol255(255, 153, 0) // Depth 3
-                }
+                },
+				PinDirectionIndicatorColor = MakeCol255(34),
 			};
 		}
 
@@ -270,6 +271,7 @@ namespace DLS.Graphics
 			public Color[] FlatColors;
 			public Color[] FlatColorsHover;
 			public Color[] PinSizeIndicatorColors;
+			public Color PinDirectionIndicatorColor;
 		}
 
 		public class UIThemeDLS

--- a/Assets/Scripts/Graphics/World/CustomizationSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/CustomizationSceneDrawer.cs
@@ -1,13 +1,13 @@
 using System;
+using System.Linq;
 using DLS.Description;
 using DLS.Game;
 using Seb.Helpers;
 using Seb.Types;
 using Seb.Vis;
-using UnityEngine;
-using System.Linq;
 using Seb.Vis.UI;
-using System.Collections.Generic;
+using UnityEngine;
+using static DLS.Graphics.DrawSettings;
 
 namespace DLS.Graphics
 {
@@ -24,6 +24,7 @@ namespace DLS.Graphics
 		static Vector2 mouseDownPos;
 		static Vector2 displayPosInitial;
 		static float displayScaleInitial;
+		
         public static PinInstance selectedPin;
         public static bool isDraggingPin;
         private static float lastValidOffset;
@@ -107,7 +108,7 @@ namespace DLS.Graphics
 			Color scaleCol = new(0.4f, 1, 0.2f);
 			float deltaScale = (mouseDownPos - InputHelper.MousePosWorld).magnitude;
 			deltaScale *= Vector2.Dot((InputHelper.MousePosWorld - mouseDownPos).normalized, (displayPosInitial - mouseDownPos).normalized);
-			float targetScale = Mathf.Max(DrawSettings.GridSize, displayScaleInitial - deltaScale);
+			float targetScale = Mathf.Max(GridSize, displayScaleInitial - deltaScale);
 
 			if (!Project.ActiveProject.ShouldSnapToGrid)
 			{
@@ -229,7 +230,7 @@ namespace DLS.Graphics
 						DisplayUnderMouse = display;
 
 						float cornerDst = bounds.DstToCorner(InputHelper.MousePosWorld);
-						float cornerDstThresholdForScaleMode = Mathf.Min(displayMinAxisSize * 0.2f, DrawSettings.GridSize * 1.5f);
+						float cornerDstThresholdForScaleMode = Mathf.Min(displayMinAxisSize * 0.2f, GridSize * 1.5f);
 						bool enterScaleMode = cornerDst < cornerDstThresholdForScaleMode;
 
 						if (enterScaleMode)
@@ -293,7 +294,7 @@ namespace DLS.Graphics
 		static void DrawPlacementCornerIndicator(Vector2 corner, Vector2 dirA, Vector2 dirB, Color col)
 		{
 			const float pad = 0.0f;
-			const float len = DrawSettings.GridSize;
+			const float len = GridSize;
 			const float thick = 0.01f;
 
 			Vector2 origin = corner - (dirA + dirB) * pad;
@@ -366,7 +367,7 @@ namespace DLS.Graphics
 
                     if (snapX && dir.x != 0)
                     {
-                        desiredSize.x = GridHelper.SnapToGridForceEven(desiredSize.x) - DrawSettings.ChipOutlineWidth;
+                        desiredSize.x = GridHelper.SnapToGridForceEven(desiredSize.x) - ChipOutlineWidth;
                     }
 
                     chip.updateMinSize();
@@ -391,96 +392,112 @@ namespace DLS.Graphics
 
         static void HandlePinDragging()
         {
-            if (!InteractionState.MouseIsOverUI)
-            {
-                // Start dragging a pin
-                if (InputHelper.IsMouseDownThisFrame(MouseButton.Left))
-                {
-                    if (InteractionState.ElementUnderMouse is PinInstance pin)
-                    {
-                        selectedPin = pin;
-                        isDraggingPin = true;
-                        lastValidOffset = pin.LocalPosY;
-                        lastValidFace = pin.face;
-                    }
-                }
+	        if (InteractionState.MouseIsOverUI) return;
+	        // Start dragging a pin
+	        if (InputHelper.IsMouseDownThisFrame(MouseButton.Left))
+	        {
+		        if (InteractionState.ElementUnderMouse is PinInstance pin)
+		        {
+			        selectedPin = pin;
+			        isDraggingPin = true;
+			        lastValidOffset = pin.LocalPosY;
+			        lastValidFace = pin.face;
+		        }
+	        }
 
-                if (isDraggingPin && selectedPin?.parent is SubChipInstance chip)
-                {
-                    Vector2 mouseWorld = InputHelper.MousePosWorld;
-                    Vector2 chipCenter = chip.Position;
-                    Vector2 localMouse = mouseWorld - chipCenter;
-                    Vector2 chipHalfSize = chip.Size / 2f;
+	        if (!isDraggingPin || selectedPin.parent is not SubChipInstance chip) return;
+	        
+	        Vector2 mouseWorld = InputHelper.MousePosWorld;
+	        Vector2 chipCenter = chip.Position;
+	        Vector2 localMouse = mouseWorld - chipCenter;
+	        Vector2 chipHalfSize = chip.Size / 2f;
 
-                    // Determine closest edge
-                    float distTop = Mathf.Abs(localMouse.y - chipHalfSize.y);
-                    float distBottom = Mathf.Abs(localMouse.y + chipHalfSize.y);
-                    float distRight = Mathf.Abs(localMouse.x - chipHalfSize.x);
-                    float distLeft = Mathf.Abs(localMouse.x + chipHalfSize.x);
+	        // Determine closest edge
+	        float distTop = Mathf.Abs(localMouse.y - chipHalfSize.y);
+	        float distBottom = Mathf.Abs(localMouse.y + chipHalfSize.y);
+	        float distRight = Mathf.Abs(localMouse.x - chipHalfSize.x);
+	        float distLeft = Mathf.Abs(localMouse.x + chipHalfSize.x);
 
-                    int closestFace = 0;
-                    float minDist = distTop;
+			int closestFace = 0;
+			float minDist = distTop;
 
-                    if (distRight < minDist) { closestFace = 1; minDist = distRight; }
-                    if (distBottom < minDist) { closestFace = 2; minDist = distBottom; }
-                    if (distLeft < minDist) { closestFace = 3; }
+	        if (distRight < minDist) { closestFace = 1; minDist = distRight; }
+	        if (distBottom < minDist) { closestFace = 2; minDist = distBottom; }
+	        if (distLeft < minDist) { closestFace = 3; }
 
-                    selectedPin.face = closestFace;
+	        selectedPin.face = closestFace;
 
-                    float pinHeight = SubChipInstance.PinHeightFromBitCount(selectedPin.bitCount);
+	        float pinHeight = SubChipInstance.PinHeightFromBitCount(selectedPin.bitCount);
 
-                    float maxOffset;
-                    float offsetAlongFace;
+	        float maxOffset;
+	        float offsetAlongFace;
 
-                    bool shouldSnapToGrid = Project.ActiveProject.ShouldSnapToGrid;
+	        bool shouldSnapToGrid = Project.ActiveProject.ShouldSnapToGrid;
 
-                    if (closestFace == 0 || closestFace == 2)
-                    {
-                        // Horizontal face - move along X axis
-                        maxOffset = chipHalfSize.x - pinHeight / 2f;
-                        offsetAlongFace = shouldSnapToGrid ? GridHelper.ClampToGrid(localMouse.x, -maxOffset, maxOffset) :
-                            Mathf.Clamp(localMouse.x, -maxOffset, maxOffset);
-                    }
-                    else
-                    {
-                        // Vertical face - move along Y axis
-                        maxOffset = chipHalfSize.y - pinHeight / 2f;
-                        offsetAlongFace = shouldSnapToGrid ? GridHelper.ClampToGrid(localMouse.y, -maxOffset, maxOffset) :
-                            Mathf.Clamp(localMouse.y, -maxOffset, maxOffset);
-                    }
+	        if (closestFace == 0 || closestFace == 2)
+	        {
+		        // Horizontal face - move along X axis
+		        maxOffset = chipHalfSize.x - pinHeight / 2f;
+		        offsetAlongFace = shouldSnapToGrid ? GridHelper.ClampToGrid(localMouse.x, -maxOffset, maxOffset) :
+			        Mathf.Clamp(localMouse.x, -maxOffset, maxOffset);
+	        }
+	        else
+	        {
+		        // Vertical face - move along Y axis
+		        maxOffset = chipHalfSize.y - pinHeight / 2f;
+		        offsetAlongFace = shouldSnapToGrid ? GridHelper.ClampToGrid(localMouse.y, -maxOffset, maxOffset) :
+			        Mathf.Clamp(localMouse.y, -maxOffset, maxOffset);
+	        }
 
-                    selectedPin.LocalPosY = offsetAlongFace;
+	        selectedPin.LocalPosY = offsetAlongFace;
 
-                    PinInstance overlappedPin;
-                    isPinPositionValid = !DoesPinOverlap(selectedPin, out overlappedPin);
+	        isPinPositionValid = !DoesPinOverlap(selectedPin, out PinInstance overlappedPin);
 
-                    // End drag on mouse release
-                    if (InputHelper.IsMouseUpThisFrame(MouseButton.Left))
-                    {
-                        if (isPinPositionValid)
-                        {
-                            lastValidOffset = offsetAlongFace;
-                            lastValidFace = selectedPin.face;
+	        //makes pins red if too close
+	        if (!isPinPositionValid)
+	        {
+		        Vector2 pinPos = overlappedPin.GetWorldPos();
+		        if (overlappedPin.bitCount == PinBitCount.Bit1)
+		        {
+			        Draw.Quad(pinPos, PinRadius * 2.4f * Vector2.one, Color.red);
+		        }
+		        else
+		        {
+			        float pinWidth = PinRadius * 2 * 0.95f;
+			        float overlappedPinHeight = SubChipInstance.PinHeightFromBitCount(overlappedPin.bitCount);
 
-                            if (!ChipCustomizationMenu.isCustomLayout)
-                            {
-                                ChipCustomizationMenu.isCustomLayout = true;
-                                UI.GetWheelSelectorState(ChipCustomizationMenu.ID_LayoutOptions).index = 1;
-                                ChipSaveMenu.ActiveCustomizeChip.SetCustomLayout(true);
-                            }
-                        }
-                        else
-                        {
-                            selectedPin.LocalPosY = lastValidOffset;
-                            selectedPin.face = lastValidFace;
-                        }
+			        Vector2 pinSize = (overlappedPin.face == 0 || overlappedPin.face == 2)
+				        ? new Vector2(overlappedPinHeight, pinWidth)  // horizontal pin
+				        : new Vector2(pinWidth, overlappedPinHeight); // vertical pin
 
-                        isDraggingPin = false;
-                        selectedPin = null;
-                        isPinPositionValid = true;
-                    }
-                }
-            }
+			        Draw.Quad(pinPos, pinSize * 1.2f, Color.red);
+		        }
+	        }
+
+	        if (!InputHelper.IsMouseUpThisFrame(MouseButton.Left)) return;
+
+	        // End drag on mouse release
+	        if (isPinPositionValid)
+	        {
+		        lastValidOffset = offsetAlongFace;
+		        lastValidFace = selectedPin.face;
+
+		        if (!ChipCustomizationMenu.isCustomLayout)
+		        {
+			        ChipCustomizationMenu.isCustomLayout = true;
+			        UI.GetWheelSelectorState(ChipCustomizationMenu.ID_LayoutOptions).index = 1;
+			        ChipSaveMenu.ActiveCustomizeChip.SetCustomLayout(true);
+		        }
+	        }
+	        else
+	        {
+		        selectedPin.LocalPosY = lastValidOffset;
+		        selectedPin.face = lastValidFace;
+	        }
+
+	        isDraggingPin = false;
+	        selectedPin = null;
+	        isPinPositionValid = true;
         }
 
         public static void Reset()
@@ -489,17 +506,12 @@ namespace DLS.Graphics
 			displayInteractState = DisplayInteractState.None;
 		}
 
-        public static bool DoesPinOverlap(PinInstance pin, out PinInstance overlappedPin)
+		static bool DoesPinOverlap(PinInstance pin, out PinInstance overlappedPin)
         {
             overlappedPin = null;
-            if (!(pin.parent is SubChipInstance chip)) return false;
+            if (pin.parent is not SubChipInstance chip) return false;
 
-            // Get all pins on the same chip to check pins on the same face as selectedpin
-            List<PinInstance> pinsToCheck = new List<PinInstance>();
-            pinsToCheck.AddRange(chip.InputPins);
-            pinsToCheck.AddRange(chip.OutputPins);
-
-            foreach (PinInstance otherPin in pinsToCheck)
+            foreach (PinInstance otherPin in chip.AllPins)
             {
                 if (otherPin == pin) continue;
 

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -894,7 +894,7 @@ namespace DLS.Graphics
 
         public static void DrawDevPin(DevPinInstance devPin)
 		{
-			if (devPin.BitCount == (uint)1)
+			if (devPin.BitCount == 1)
 			{
 				Draw1BitDevPin(devPin);
 			}
@@ -1221,21 +1221,14 @@ namespace DLS.Graphics
         {
             Vector2 pinPos = pin.GetWorldPos();
 
-            bool isHorizontal = pin.FacingDir == Vector2.up || pin.FacingDir == Vector2.down;
+            Vector2 dir = pin.FacingDir;
+            bool isHorizontal = dir == Vector2.up || dir == Vector2.down;
             float pinWidth = PinRadius * 2 * 0.95f;
             float pinHeight = SubChipInstance.PinHeightFromBitCount(pin.bitCount);
             Vector2 pinSize = isHorizontal ? new Vector2(pinHeight, pinWidth) : new Vector2(pinWidth, pinHeight);
 
             // Determine direction for selection offset (used for mouse interaction)
-            Vector2 offsetDir = Vector2.zero;
-            switch (pin.face)
-            {
-                case 1: offsetDir = Vector2.left; break;  // right face
-                case 3: offsetDir = Vector2.right; break; // left face
-            }
-
-
-            Vector2 pinSelectionBoundsPos = pinPos + offsetDir * 0.02f;
+            Vector2 pinSelectionBoundsPos = pinPos -dir * 0.02f;
             bool mouseOverPin = !InteractionState.MouseIsOverUI &&
                                 InputHelper.MouseInsideBounds_World(pinSelectionBoundsPos, pinSize);
             if (mouseOverPin)
@@ -1257,63 +1250,51 @@ namespace DLS.Graphics
 			if (pin.bitCount >= 64 && !mouseOverPin)
 			{
 				Vector2 depthIndicatorSize = isHorizontal ? new(pinHeight, pinWidth / 8f) : new(pinWidth / 8f, pinHeight);
-				Draw.Quad(pinPos + 0.25f * pinWidth * pin.FacingDir, depthIndicatorSize, ActiveTheme.PinSizeIndicatorColors[pin.bitCount.GetTier()]);
+				Draw.Quad(pinPos + 0.25f * pinWidth * dir, depthIndicatorSize, ActiveTheme.PinSizeIndicatorColors[pin.bitCount.GetTier()]);
 			}
 
             // Draws input/output indicators on subchip pins only
-            bool isOnCustomChip = pin.parent is SubChipInstance;
-			if (isOnCustomChip)
-			{
-                //set up display mode based on settings
-                int pinIndicatorMode = Project.ActiveProject.description.Perfs_PinIndicators;
-                bool drawIndicator = false;
-                switch (pinIndicatorMode)
-                {
-                    case 1: // "On Hover"
-                        drawIndicator = mouseOverPin;
-                        break;
-                    case 2: // "Tab To Toggle"
-                        drawIndicator = Project.ActiveProject.PinNameDisplayIsTabToggledOn;
-                        break;
-                    case 3: // "If Pin is not connected"
-	                    bool isConnected = IsConnected(pin);
-                        drawIndicator = !isConnected;
-                        break;
-                    case 4: // "Always"
-                        drawIndicator = true;
-                        break;   
-                }
-                if (drawIndicator)
-				{
-                    Vector2 dir;
-                    switch (pin.face)
-                    {
-                        case 0: dir = Vector2.down; break;
-                        case 1: dir = Vector2.left; break;
-                        case 2: dir = Vector2.up; break;
-                        case 3: dir = Vector2.right; break;
-                        default: dir = Vector2.zero; break;
-                    }
-                    if (pin.IsSourcePin) { dir = -dir; }
-                    float pinThickness = isHorizontal ? pinSize.y : pinSize.x;
-                    float arrowLength = pinThickness / 2f;
-                    float arrowWidth = arrowLength * 2f;
-                    Vector2 perp = new Vector2(-dir.y, dir.x);
+            if (pin.parent is not SubChipInstance) return;
+            
+            //set up display mode based on settings
+            int pinIndicatorMode = Project.ActiveProject.description.Perfs_PinIndicators;
+            bool drawIndicator = false;
+            switch (pinIndicatorMode)
+            {
+	            case 1: // "On Hover"
+		            drawIndicator = mouseOverPin;
+		            break;
+	            case 2: // "Tab To Toggle"
+		            drawIndicator = Project.ActiveProject.PinNameDisplayIsTabToggledOn;
+		            break;
+	            case 3: // "If Pin is not connected"
+		            bool isConnected = IsConnected(pin);
+		            drawIndicator = !isConnected;
+		            break;
+	            case 4: // "Always"
+		            drawIndicator = true;
+		            break;   
+            }
 
+            if (!drawIndicator) return;
 
-                    float edgeOffset = pinThickness / 4f;
+            float pinThickness = isHorizontal ? pinSize.y : pinSize.x;
+            float arrowLength = pinThickness / 2f;
+            float edgeOffset = pinThickness / 4f;
 
-                    //Shifts arrow based on if input/output to ensure it's not hidden behind subChip
-                    Vector2 centerOffset = edgeOffset * (pin.IsSourcePin ? 1 : -1) * dir;
-                    Vector2 arrowCenter = pinPos + centerOffset;
+            dir = -dir;
+            if (pin.IsSourcePin) { dir = -dir; }
 
-                    Vector2 tip = arrowCenter + dir * (arrowLength / 2f);
-                    Vector2 baseCenter = arrowCenter - dir * (arrowLength / 2f);
-                    Vector2 baseLeft = baseCenter + perp * (arrowWidth / 2f);
-                    Vector2 baseRight = baseCenter - perp * (arrowWidth / 2f);
-                    Draw.Triangle(tip, baseLeft, baseRight, new Color(34f / 255f, 34f / 255f, 34f / 255f, 1f));
-                }
-			}
+            Vector2 perp = new Vector2(-dir.y, dir.x);
+            //Shifts arrow based on if input/output to ensure it's not hidden behind subChip
+            Vector2 centerOffset = edgeOffset * (pin.IsSourcePin ? 1 : -1) * dir;
+            Vector2 arrowCenter = pinPos + centerOffset;
+
+            Vector2 tip = arrowCenter + dir * edgeOffset;
+            Vector2 baseCenter = arrowCenter - dir * edgeOffset;
+            Vector2 baseLeft = baseCenter + perp * arrowLength;
+            Vector2 baseRight = baseCenter - perp * arrowLength;
+            Draw.Triangle(tip, baseLeft, baseRight, new Color(34f / 255f, 34f / 255f, 34f / 255f, 1f));
         }
 
 		/// Check if pin is connect to any wire for the Is Disconnected setting

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -745,7 +745,7 @@ namespace DLS.Graphics
 				}
 			}
 
-			if (simSource != null) simSource.OutputPins[3].State.SmallSet(addr == null ? 0 : addr.Value);
+			simSource?.OutputPins[3].State.SmallSet(addr ?? 0);
 
 			return (bounds, inBounds, pressed);
 
@@ -849,7 +849,6 @@ namespace DLS.Graphics
             bool inBounds = false;
             bool gettingClicked = false;
 
-            int currentSwitchHeadPos = 1;
             int nextSwitchHeadPos = 1;
 
 
@@ -865,9 +864,9 @@ namespace DLS.Graphics
 
             if (chipSource != null)
             {
-				bool currentState = (chipSource.InternalState[0] & 1) == 1 ? true : false;
-				currentSwitchHeadPos = currentState ? -1 : 1;
-                Bounds2D bounds = Bounds2D.CreateFromCentreAndSize(centre + Vector2.up * verticalOffset * currentSwitchHeadPos, switchDrawSize);
+				bool currentState = (chipSource.InternalState[0] & 1) == 1;
+				int currentSwitchHeadPos = currentState ? -1 : 1;
+                Bounds2D bounds = Bounds2D.CreateFromCentreAndSize(centre + verticalOffset * currentSwitchHeadPos * Vector2.up, switchDrawSize);
                 inBounds = bounds.PointInBounds(InputHelper.MousePosWorld);
                 gettingClicked = inBounds && InputHelper.IsMouseDownThisFrame(MouseButton.Left) && controller.CanInteractWithButton;
 				bool nextState = gettingClicked ? !currentState : currentState;
@@ -929,7 +928,7 @@ namespace DLS.Graphics
 			Draw.Point(devPin.StateDisplayPosition, DevPinStateDisplayRadius, stateCol);
 
 			// Draw pin and handle
-			DrawPin(devPin.Pin);
+			DrawSingleBitPin(devPin.Pin);
 			DrawPinHandle(devPin, devPin.HandlePosition, devPin.GetHandleSize());
 		}
 
@@ -985,7 +984,7 @@ namespace DLS.Graphics
 			}
 
 			// Draw pin and handle
-			DrawPin(devPin.Pin);
+			DrawMultiBitPin(devPin.Pin);
 			DrawPinHandle(devPin, devPin.HandlePosition, devPin.GetHandleSize());
 		}
 
@@ -1181,32 +1180,10 @@ namespace DLS.Graphics
 			Draw.Point(pinPos, PinRadius, pinCol);
 
 			// ---- input/output arrow ----
-			// Draws input/output indicators on subchip pins only
-			if (pin.parent is not SubChipInstance) return;
-			
-			//set up display mode based on settings
-			int pinIndicatorMode = Project.ActiveProject.description.Perfs_PinIndicators;
-			bool drawIndicator = false;
-			switch (pinIndicatorMode)
-			{
-				case 1: // "On Hover"
-					drawIndicator = mouseOverPin;
-					break;
-				case 2: // "Tab To Toggle"
-					drawIndicator = Project.ActiveProject.PinNameDisplayIsTabToggledOn;
-					break;
-				case 3: // "If Pin is not connected"
-					var isConnected = IsConnected(pin);
-					drawIndicator = !isConnected;
-					break;
-				case 4: // "Always"
-					drawIndicator = true;
-					break;
-			}
+			// Draw input/output indicators on subChip pins only
+			if (!ShouldDrawIndicator(pin, mouseOverPin)) return;
 
-			if (!drawIndicator) return;
-
-			Draw.Point(pinPos, PinRadius, new Color(34f / 255f, 34f / 255f, 34f / 255f, 1f));
+			Draw.Point(pinPos, PinRadius, ActiveTheme.PinDirectionIndicatorColor);
 			Vector2 dir = pin.FacingDir;
 			float angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
 
@@ -1222,8 +1199,7 @@ namespace DLS.Graphics
             Vector2 pinPos = pin.GetWorldPos();
 
             Vector2 dir = pin.FacingDir;
-            bool isDevPin = pin.parent is DevPinInstance;
-            if (isDevPin)
+            if (pin.parent is DevPinInstance)
             {
 	            dir = pin.IsSourcePin ? Vector2.right : Vector2.left;
             }
@@ -1233,7 +1209,7 @@ namespace DLS.Graphics
             Vector2 pinSize = isHorizontal ? new Vector2(pinHeight, pinWidth) : new Vector2(pinWidth, pinHeight);
 
             // Determine direction for selection offset (used for mouse interaction)
-            Vector2 pinSelectionBoundsPos = pinPos -dir * 0.02f;
+            Vector2 pinSelectionBoundsPos = pinPos - dir * 0.02f;
             bool mouseOverPin = !InteractionState.MouseIsOverUI &&
                                 InputHelper.MouseInsideBounds_World(pinSelectionBoundsPos, pinSize);
             if (mouseOverPin)
@@ -1251,37 +1227,15 @@ namespace DLS.Graphics
             Draw.Quad(pinPos, pinSize, pinCol);
 
 
-			// Draw pin indicator
+			// Draw pin size indicator
 			if (pin.bitCount >= 64 && !mouseOverPin)
 			{
 				Vector2 depthIndicatorSize = isHorizontal ? new(pinHeight, pinWidth / 8f) : new(pinWidth / 8f, pinHeight);
 				Draw.Quad(pinPos + 0.25f * pinWidth * dir, depthIndicatorSize, ActiveTheme.PinSizeIndicatorColors[pin.bitCount.GetTier()]);
 			}
 
-            // Draws input/output indicators on subchip pins only
-            if (isDevPin) return;
-            
-            //set up display mode based on settings
-            int pinIndicatorMode = Project.ActiveProject.description.Perfs_PinIndicators;
-            bool drawIndicator = false;
-            switch (pinIndicatorMode)
-            {
-	            case 1: // "On Hover"
-		            drawIndicator = mouseOverPin;
-		            break;
-	            case 2: // "Tab To Toggle"
-		            drawIndicator = Project.ActiveProject.PinNameDisplayIsTabToggledOn;
-		            break;
-	            case 3: // "If Pin is not connected"
-		            bool isConnected = IsConnected(pin);
-		            drawIndicator = !isConnected;
-		            break;
-	            case 4: // "Always"
-		            drawIndicator = true;
-		            break;   
-            }
-
-            if (!drawIndicator) return;
+            // Draw input/output direction indicators on subChip pins only
+            if (!ShouldDrawIndicator(pin, mouseOverPin)) return;
 
             float pinThickness = isHorizontal ? pinSize.y : pinSize.x;
             float arrowLength = pinThickness / 2f;
@@ -1299,13 +1253,13 @@ namespace DLS.Graphics
             Vector2 baseCenter = arrowCenter - dir * edgeOffset;
             Vector2 baseLeft = baseCenter + perp * arrowLength;
             Vector2 baseRight = baseCenter - perp * arrowLength;
-            Draw.Triangle(tip, baseLeft, baseRight, new Color(34f / 255f, 34f / 255f, 34f / 255f, 1f));
+            Draw.Triangle(tip, baseLeft, baseRight, ActiveTheme.PinDirectionIndicatorColor);
         }
 
 		/// Check if pin is connect to any wire for the Is Disconnected setting
 		static bool IsConnected(PinInstance pin)
 		{
-			List<WireInstance> wireList = Project.ActiveProject.controller.ActiveDevChip.Wires;
+			List<WireInstance> wireList = controller.ActiveDevChip.Wires;
 			bool isConnected = false;
 			for (int i = wireList.Count - 1; i >= 0; i--)
 			{
@@ -1318,6 +1272,32 @@ namespace DLS.Graphics
 			}
 
 			return isConnected;
+		}
+
+		/// <summary>
+		/// Should an indicator of the input/ output direction of the given pin be drawn?
+		/// </summary>
+		/// <returns>False if pin is <see cref="DevPinInstance"/>, or the indicator mode doesn't match</returns>
+		/// <exception cref="NotImplementedException"></exception>
+		static bool ShouldDrawIndicator(PinInstance pin, bool mouseOverPin)
+		{
+			if (pin.parent is not SubChipInstance) return false;
+			
+			int pinIndicatorMode = Project.ActiveProject.description.Perfs_PinIndicators;
+			return pinIndicatorMode switch
+			{
+				0 => // "Never"
+					false,
+				1 => // "On Hover"
+					mouseOverPin,
+				2 => // "Tab To Toggle"
+					Project.ActiveProject.PinNameDisplayIsTabToggledOn,
+				3 => // "If Pin is not connected"
+					!IsConnected(pin),
+				4 => // "Always"
+					true,
+				_ => throw new NotImplementedException($"Pin indicator mode {pinIndicatorMode} is not implemented.")
+			};
 		}
 
 		public static void DrawGrid(Color gridCol)

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -590,7 +590,6 @@ namespace DLS.Graphics
 					{
 						int address = y * 16 + x;
 						uint pixelState = simSource.InternalState[address];
-						float v = pixelState;
 						col = new Color(pixelState, pixelState, pixelState);
 					}
 
@@ -950,7 +949,7 @@ namespace DLS.Graphics
 
 			Vector2 topLeft = new(centre.x - inputGridSizeWithoutOutline.x / 2, centre.y + inputGridSizeWithoutOutline.y / 2);
 			Draw.Quad(centre, inputGridSize, Color.black);
-			int currBitIndex = (int)devPin.BitCount - 1;
+			int currBitIndex = devPin.BitCount - 1;
 
 			bool mouseOverStateGrid = InputHelper.MouseInsideBounds_World(centre, inputGridSize);
 			bool isInteractable = controller.CanInteractWithPinStateDisplay && devPin.IsInputPin;
@@ -1159,27 +1158,6 @@ namespace DLS.Graphics
 			{
 				DrawMultiBitPin(pin);
 			}
-
-            //makes pins red if too close
-            if (CustomizationSceneDrawer.isDraggingPin && CustomizationSceneDrawer.selectedPin == pin && !CustomizationSceneDrawer.isPinPositionValid)
-            {
-                Vector2 pinPos = pin.GetWorldPos();
-                if (pin.bitCount == PinBitCount.Bit1)
-                {
-                    Draw.Quad(pinPos, Vector2.one * PinRadius * 2.4f, Color.red);
-                }
-                else
-                {
-                    float pinWidth = PinRadius * 2 * 0.95f;
-                    float pinHeight = SubChipInstance.PinHeightFromBitCount(pin.bitCount);
-
-                    Vector2 pinSize = (pin.face == 0 || pin.face == 2)
-                        ? new Vector2(pinHeight, pinWidth)  // horizontal pin
-                        : new Vector2(pinWidth, pinHeight); // vertical pin
-
-                    Draw.Quad(pinPos, pinSize * 1.2f, Color.red);
-                }
-            }
         }
 
         static void DrawSingleBitPin(PinInstance pin)
@@ -1243,7 +1221,7 @@ namespace DLS.Graphics
         {
             Vector2 pinPos = pin.GetWorldPos();
 
-            bool isHorizontal = pin.face == 0 || pin.face == 2;
+            bool isHorizontal = pin.FacingDir == Vector2.up || pin.FacingDir == Vector2.down;
             float pinWidth = PinRadius * 2 * 0.95f;
             float pinHeight = SubChipInstance.PinHeightFromBitCount(pin.bitCount);
             Vector2 pinSize = isHorizontal ? new Vector2(pinHeight, pinWidth) : new Vector2(pinWidth, pinHeight);

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -233,7 +233,7 @@ namespace DLS.Graphics
 
 			int charCount;
 
-			if (pin.Pin.State.IsValueBiggerThanInt() || (((pin.GetStateDecimalDisplayValue()&(1<<31)) == (1<<31)) && pin.pinValueDisplayMode!=PinValueDisplayMode.SignedDecimal) )
+			if (pin.Pin.State.IsValueBiggerThanInt() || ((pin.GetStateDecimalDisplayValue()&(1<<31)) == 1<<31 && pin.pinValueDisplayMode!=PinValueDisplayMode.SignedDecimal) )
 			{
 				charCount = 7;
 				CopyToCharBuffer(pin, "TOO BIG");
@@ -688,9 +688,9 @@ namespace DLS.Graphics
 			}
 
 			if (inBounds)
-				{
-					InteractionState.NotifyElementUnderMouse(display);
-				}
+			{
+				InteractionState.NotifyElementUnderMouse(display);
+			}
 
 			rootChip.IsSelected = clicked ? false : rootChip.IsSelected;
 
@@ -1203,92 +1203,42 @@ namespace DLS.Graphics
 			Draw.Point(pinPos, PinRadius, pinCol);
 
 			// ---- input/output arrow ----
-
-			Vector2 dir = pin.face switch
-			{
-				0 => Vector2.down,
-				1 => Vector2.left,
-				2 => Vector2.up,
-				3 => Vector2.right,
-				_ => Vector2.zero,
-			};
-			if (pin.IsSourcePin)
-			{
-				dir = -dir;
-
-			}
-			float pinThickness = PinRadius * 2f;
-			float arrowLength = pinThickness * 0.35f;
-			float arrowWidth = arrowLength * 1.2f;
-			Vector2 perp = new Vector2(-dir.y, dir.x);
-			float edgeOffset = pinThickness / 4f;
-			Vector2 centerOffset = dir * edgeOffset * (pin.IsSourcePin ? 1 : -1);
-			Vector2 arrowCenter = pinPos + centerOffset;
-			Vector2 tip = arrowCenter + dir * (arrowLength / 2f);
-			Vector2 baseCenter = arrowCenter - dir * (arrowLength / 2f);
-			Vector2 baseLeft = baseCenter + perp * (arrowWidth / 2f);
-			Vector2 baseRight = baseCenter - perp * (arrowWidth / 2f);
-
 			// Draws input/output indicators on subchip pins only
-			bool isInputToCustomChip = pin.parent is SubChipInstance;
-			if (isInputToCustomChip)
+			if (pin.parent is not SubChipInstance) return;
+			
+			//set up display mode based on settings
+			int pinIndicatorMode = Project.ActiveProject.description.Perfs_PinIndicators;
+			bool drawIndicator = false;
+			switch (pinIndicatorMode)
 			{
-                // Check if pin is connect to any wire for the Is Disconnected setting
-                
-                List<WireInstance> wireList = Project.ActiveProject.controller.ActiveDevChip.Wires;
-                bool isConnected = false;
-                for (int i = wireList.Count - 1; i >= 0; i--)
-                {
-                    WireInstance wire = wireList[i];
-                    if (PinAddress.Equals(wire.SourcePin.Address, pin.Address) || PinAddress.Equals(wire.TargetPin.Address, pin.Address))
-                    {
-                        isConnected = true;
-                        break;
-                    }
-
-                }
-                //set up display mode based on settings
-                int pinIndicatorMode = Project.ActiveProject.description.Perfs_PinIndicators;
-                bool drawIndicator = false;
-                switch (pinIndicatorMode)
-                {
-                    case 1: // "On Hover"
-                        drawIndicator = mouseOverPin;
-                        break;
-                    case 2: // "Tab To Toggle"
-                        drawIndicator = Project.ActiveProject.PinNameDisplayIsTabToggledOn;
-                        break;
-                    case 3: // "If Pin is not connected"
-                        drawIndicator = !isConnected;
-                        break;
-                    case 4: // "Always"
-                        drawIndicator = true;
-                        break;
-
-                }
-                if (drawIndicator)
-
-                {
-						Draw.Point(pinPos, PinRadius, new Color(34f / 255f, 34f / 255f, 34f / 255f, 1f));
-						float angle = 0;
-						float wedgeSpan = 0f;
-
-						if (!pin.IsSourcePin)
-						{
-							wedgeSpan = 100f; //edit angle of input
-							angle = Mathf.Atan2(-dir.y, -dir.x) * Mathf.Rad2Deg;
-						}
-						else
-						{
-							wedgeSpan = 150f; //edits angle of output
-							angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
-						}
-						float angleStart = angle - wedgeSpan / 2f;
-						float angleEnd = angle + wedgeSpan / 2f;
-						Draw.WedgePolygon(pinPos, PinRadius, angleStart, angleEnd, ActiveTheme.PinCol, pin.face, pin.IsSourcePin);
-					}
-				}
+				case 1: // "On Hover"
+					drawIndicator = mouseOverPin;
+					break;
+				case 2: // "Tab To Toggle"
+					drawIndicator = Project.ActiveProject.PinNameDisplayIsTabToggledOn;
+					break;
+				case 3: // "If Pin is not connected"
+					var isConnected = IsConnected(pin);
+					drawIndicator = !isConnected;
+					break;
+				case 4: // "Always"
+					drawIndicator = true;
+					break;
 			}
+
+			if (!drawIndicator) return;
+
+			Draw.Point(pinPos, PinRadius, new Color(34f / 255f, 34f / 255f, 34f / 255f, 1f));
+			Vector2 dir = pin.FacingDir;
+			float angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
+
+			bool pinIsSourcePin = pin.IsSourcePin;
+			var wedgeSpan = pinIsSourcePin ? 75f : 50f; //edits angle of input/output
+			float angleStart = angle - wedgeSpan;
+			float angleEnd = angle + wedgeSpan;
+			Draw.WedgePolygon(pinPos, PinRadius, angleStart, angleEnd, ActiveTheme.PinCol, pin.face, pinIsSourcePin);
+		}
+
 		static void DrawMultiBitPin(PinInstance pin)
         {
             Vector2 pinPos = pin.GetWorldPos();
@@ -1329,26 +1279,13 @@ namespace DLS.Graphics
 			if (pin.bitCount >= 64 && !mouseOverPin)
 			{
 				Vector2 depthIndicatorSize = isHorizontal ? new(pinHeight, pinWidth / 8f) : new(pinWidth / 8f, pinHeight);
-				Draw.Quad(pinPos + pin.FacingDir * 0.25f * pinWidth, depthIndicatorSize, ActiveTheme.PinSizeIndicatorColors[pin.bitCount.GetTier()]);
+				Draw.Quad(pinPos + 0.25f * pinWidth * pin.FacingDir, depthIndicatorSize, ActiveTheme.PinSizeIndicatorColors[pin.bitCount.GetTier()]);
 			}
 
             // Draws input/output indicators on subchip pins only
             bool isOnCustomChip = pin.parent is SubChipInstance;
 			if (isOnCustomChip)
 			{
-                // Check if pin is connect to any wire 
-                List<WireInstance> wireList = Project.ActiveProject.controller.ActiveDevChip.Wires;
-                bool isConnected = false;
-                for (int i = wireList.Count - 1; i >= 0; i--)
-				{
-					WireInstance wire = wireList[i];
-                    if (PinAddress.Equals(wire.SourcePin.Address, pin.Address) || PinAddress.Equals(wire.TargetPin.Address, pin.Address))
-					{
-						isConnected = true;
-						break;
-                    }
-					
-				}
                 //set up display mode based on settings
                 int pinIndicatorMode = Project.ActiveProject.description.Perfs_PinIndicators;
                 bool drawIndicator = false;
@@ -1361,6 +1298,7 @@ namespace DLS.Graphics
                         drawIndicator = Project.ActiveProject.PinNameDisplayIsTabToggledOn;
                         break;
                     case 3: // "If Pin is not connected"
+	                    bool isConnected = IsConnected(pin);
                         drawIndicator = !isConnected;
                         break;
                     case 4: // "Always"
@@ -1387,8 +1325,8 @@ namespace DLS.Graphics
 
                     float edgeOffset = pinThickness / 4f;
 
-                    //Shifts arrow based on if input/output to ensure its not hidden behind subchip
-                    Vector2 centerOffset = dir * edgeOffset * (pin.IsSourcePin ? 1 : -1);
+                    //Shifts arrow based on if input/output to ensure it's not hidden behind subChip
+                    Vector2 centerOffset = edgeOffset * (pin.IsSourcePin ? 1 : -1) * dir;
                     Vector2 arrowCenter = pinPos + centerOffset;
 
                     Vector2 tip = arrowCenter + dir * (arrowLength / 2f);
@@ -1398,10 +1336,27 @@ namespace DLS.Graphics
                     Draw.Triangle(tip, baseLeft, baseRight, new Color(34f / 255f, 34f / 255f, 34f / 255f, 1f));
                 }
 			}
-
-
         }
-        public static void DrawGrid(Color gridCol)
+
+		/// Check if pin is connect to any wire for the Is Disconnected setting
+		static bool IsConnected(PinInstance pin)
+		{
+			List<WireInstance> wireList = Project.ActiveProject.controller.ActiveDevChip.Wires;
+			bool isConnected = false;
+			for (int i = wireList.Count - 1; i >= 0; i--)
+			{
+				WireInstance wire = wireList[i];
+				if (PinAddress.Equals(wire.SourcePin.Address, pin.Address) || PinAddress.Equals(wire.TargetPin.Address, pin.Address))
+				{
+					isConnected = true;
+					break;
+				}
+			}
+
+			return isConnected;
+		}
+
+		public static void DrawGrid(Color gridCol)
 		{
 			float thickness = GridThickness;
 
@@ -1461,7 +1416,7 @@ namespace DLS.Graphics
 			int drawPriority_signalHigh = wireIsHigh ? 1000 : 0;
 
 			// Draw multi-bit wires above single bit wires
-			int drawPriority_bitCount = (int)wire.bitCount * 1000;
+			int drawPriority_bitCount = wire.bitCount * 1000;
 
 			// If a wire is connected to another wire, it should be drawn beneath it
 			// (mainly important for multi-bit wires, since these look strange otherwise)

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -1222,6 +1222,11 @@ namespace DLS.Graphics
             Vector2 pinPos = pin.GetWorldPos();
 
             Vector2 dir = pin.FacingDir;
+            bool isDevPin = pin.parent is DevPinInstance;
+            if (isDevPin)
+            {
+	            dir = pin.IsSourcePin ? Vector2.right : Vector2.left;
+            }
             bool isHorizontal = dir == Vector2.up || dir == Vector2.down;
             float pinWidth = PinRadius * 2 * 0.95f;
             float pinHeight = SubChipInstance.PinHeightFromBitCount(pin.bitCount);
@@ -1254,7 +1259,7 @@ namespace DLS.Graphics
 			}
 
             // Draws input/output indicators on subchip pins only
-            if (pin.parent is not SubChipInstance) return;
+            if (isDevPin) return;
             
             //set up display mode based on settings
             int pinIndicatorMode = Project.ActiveProject.description.Perfs_PinIndicators;

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -1177,12 +1177,14 @@ namespace DLS.Graphics
 				pinCol = ActiveTheme.PinInvalidCol;
 			}
 
-			Draw.Point(pinPos, PinRadius, pinCol);
+			// Draw input/output indicators on subChip pins only
+			if (!ShouldDrawIndicator(pin, mouseOverPin))
+			{
+				Draw.Point(pinPos, PinRadius, pinCol);
+				return;
+			}
 
 			// ---- input/output arrow ----
-			// Draw input/output indicators on subChip pins only
-			if (!ShouldDrawIndicator(pin, mouseOverPin)) return;
-
 			Draw.Point(pinPos, PinRadius, ActiveTheme.PinDirectionIndicatorColor);
 			Vector2 dir = pin.FacingDir;
 			float angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
@@ -1237,12 +1239,10 @@ namespace DLS.Graphics
             // Draw input/output direction indicators on subChip pins only
             if (!ShouldDrawIndicator(pin, mouseOverPin)) return;
 
-            float pinThickness = isHorizontal ? pinSize.y : pinSize.x;
-            float arrowLength = pinThickness / 2f;
-            float edgeOffset = pinThickness / 4f;
+            float arrowLength = pinWidth / 2f;
+            float edgeOffset = pinWidth / 4f;
 
-            dir = -dir;
-            if (pin.IsSourcePin) { dir = -dir; }
+            if (!pin.IsSourcePin) { dir = -dir; }
 
             Vector2 perp = new Vector2(-dir.y, dir.x);
             //Shifts arrow based on if input/output to ensure it's not hidden behind subChip


### PR DESCRIPTION
- Removed lots of unused variables and unnecessary calculations. 
- Optimized order of checks, don't iterate over every wire in project for every pin on a subchip, regardless of indicator mode anymore, just as needed.
- Move overlapping pin highlighting to customization scene drawer.
