### PR TITLE
Auto star saved chips setting

### DIFF
--- a/Assets/Scripts/Description/Types/ProjectDescription.cs
+++ b/Assets/Scripts/Description/Types/ProjectDescription.cs
@@ -33,10 +33,11 @@ namespace DLS.Description
 		public int Prefs_SimTargetStepsPerSecond;
 		public int Prefs_SimStepsPerClockTick;
 		public int Perfs_PinIndicators;
+		public bool Prefs_AddNewChipToStarredItems;
 
 		// Stats
 		public ulong StepsRanSinceCreated;
-		public CustomStopwatch /* We should ask Stack Overflow why we cannot access this class from outside its namespace */ TimeSpentSinceCreated;
+		public CustomStopwatch TimeSpentSinceCreated;
 
 		// List of all player-created chips (in order of creation -- oldest first)
 		public string[] AllCustomChipNames;
@@ -172,7 +173,6 @@ namespace DLS.Description
             result.Add(SplitMergeNames()[indexNext]);
             return result;
         }
-
     }
 
 

--- a/Assets/Scripts/Game/Main/Main.cs
+++ b/Assets/Scripts/Game/Main/Main.cs
@@ -100,6 +100,7 @@ namespace DLS.Game
 				TimeSpentSinceCreated = new(),
 				Prefs_ChipPinNamesDisplayMode = PreferencesMenu.DisplayMode_OnHover,
 				Prefs_MainPinNamesDisplayMode = PreferencesMenu.DisplayMode_OnHover,
+				Prefs_AddNewChipToStarredItems = true,
 				Prefs_SimTargetStepsPerSecond = 1000,
 				Prefs_SimStepsPerClockTick = 250,
 				Prefs_SimPaused = false,

--- a/Assets/Scripts/Game/Project/Project.cs
+++ b/Assets/Scripts/Game/Project/Project.cs
@@ -213,10 +213,13 @@ namespace DLS.Game
 				chipLibrary.NotifyChipSaved(saveChipDescription);
 				bool isNewChip = !ChipHasBeenSavedBefore || saveMode is SaveMode.SaveAs;
 
-				// New chips are automatically starred
 				if (isNewChip)
 				{
-					SetStarred(saveChipDescription.Name, true, false, false);
+					// Only add chip to starred items when user wants to.
+					if (description.Prefs_AddNewChipToStarredItems)
+					{
+						SetStarred(saveChipDescription.Name, true, false, false);
+					}
 					UpdateAndSaveProjectDescription();
 				}
 			}

--- a/Assets/Scripts/Graphics/UI/Menus/PreferencesMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/PreferencesMenu.cs
@@ -13,7 +13,7 @@ namespace DLS.Graphics
 	{
 		const float entrySpacing = 0.5f;
 		const float menuWidth = 55;
-		const float verticalOffset = 22;
+		const float verticalOffset = 24.8f;
 
 		public const int DisplayMode_Always = 0;
 		public const int DisplayMode_OnHover = 1;
@@ -51,6 +51,7 @@ namespace DLS.Graphics
 			"Active",
 			"Paused"
 		};
+
 		static readonly string[] PinIndicators =
         {
             "Off",
@@ -59,6 +60,12 @@ namespace DLS.Graphics
 			"On Disconnected",
 			"Always"
         };
+
+		static readonly string[] AutoStarNewChipsOptions =
+		{
+			"Off",
+			"On"
+		};
 
 		static readonly Vector2 entrySize = new(menuWidth, DrawSettings.SelectorWheelHeight);
 		public static readonly Vector2 settingFieldSize = new(entrySize.x / 3, entrySize.y);
@@ -73,7 +80,9 @@ namespace DLS.Graphics
 		static readonly UIHandle ID_SimFrequencyField = new("PREFS_SimTickTarget");
 		static readonly UIHandle ID_ClockSpeedInput = new("PREFS_ClockSpeed");
 		static readonly UIHandle ID_PinIndicators = new("PREFS_PinIndicators");
+		static readonly UIHandle ID_AutoStarNewChips = new("PREFS_AutoStarNewChips");
 
+		static readonly string autoStarNewChipsLabel = "Star saved chips";
         static readonly string showGridLabel = "Show grid" + CreateShortcutString("Ctrl+G");
 		static readonly string simStatusLabel = "Sim Status" + CreateShortcutString("Ctrl+Space");
 		static readonly Func<string, bool> integerInputValidator = ValidateIntegerInput;
@@ -88,8 +97,6 @@ namespace DLS.Graphics
 
 		public static void DrawMenu(Project project)
 		{
-			//HandleKeyboardShortcuts();
-
 			DrawSettings.UIThemeDLS theme = DrawSettings.ActiveUITheme;
 			MenuHelper.DrawBackgroundOverlay();
 			Draw.ID panelID = UI.ReservePanel();
@@ -114,9 +121,16 @@ namespace DLS.Graphics
 				int chipPinNamesMode = DrawNextWheel("Show chip pin names", PinDisplayOptions, ID_ChipPinNames);
 				int gridDisplayMode = DrawNextWheel(showGridLabel, GridDisplayOptions, ID_GridDisplay);
 				int pinIndicatorsMode = DrawNextWheel("Show Pin indicators",PinIndicators, ID_PinIndicators);
+				
                 DrawHeader("EDITING:");
 				int snappingMode = DrawNextWheel("Snap to grid", SnappingOptions, ID_Snapping);
 				int straightWireMode = DrawNextWheel("Straight wires", StraightWireOptions, ID_StraightWires);
+				
+				DrawHeader("SAVING:");
+				bool autoStarNewChips = MenuHelper.LabeledOptionsWheel(autoStarNewChipsLabel, labelCol, labelPosCurr,
+					entrySize, ID_AutoStarNewChips,
+					AutoStarNewChipsOptions, settingFieldSize.x, true) == 1;
+				AddSpacing();
 
 				DrawHeader("SIMULATION:");
 				bool pauseSim = MenuHelper.LabeledOptionsWheel(simStatusLabel, labelCol, labelPosCurr, entrySize, ID_SimStatus, SimulationStatusOptions, settingFieldSize.x, true) == 1;
@@ -156,6 +170,7 @@ namespace DLS.Graphics
 				project.description.Prefs_SimStepsPerClockTick = clockSpeed;
 				project.description.Prefs_SimPaused = pauseSim;
 				project.description.Perfs_PinIndicators = pinIndicatorsMode;
+				project.description.Prefs_AddNewChipToStarredItems = autoStarNewChips;
 
                 // Cancel / Confirm
                 if (result == MenuHelper.CancelConfirmResult.Cancel)
@@ -224,6 +239,7 @@ namespace DLS.Graphics
 			UI.GetWheelSelectorState(ID_StraightWires).index = projDesc.Prefs_StraightWires;
 			UI.GetWheelSelectorState(ID_SimStatus).index = projDesc.Prefs_SimPaused ? 1 : 0;
 			UI.GetWheelSelectorState(ID_PinIndicators).index = projDesc.Perfs_PinIndicators;
+			UI.GetWheelSelectorState(ID_AutoStarNewChips).index = projDesc.Prefs_AddNewChipToStarredItems ? 1 : 0;
             // -- Input fields
             UI.GetInputFieldState(ID_SimFrequencyField).SetText(projDesc.Prefs_SimTargetStepsPerSecond + "", false);
 			UI.GetInputFieldState(ID_ClockSpeedInput).SetText(projDesc.Prefs_SimStepsPerClockTick + "", false);

--- a/Assets/Scripts/SaveSystem/UpgradeHelper.cs
+++ b/Assets/Scripts/SaveSystem/UpgradeHelper.cs
@@ -2,13 +2,11 @@ using System.Collections.Generic;
 using System.Linq;
 using DLS.Description;
 using DLS.Game;
-using UnityEngine;
 
 namespace DLS.SaveSystem
 {
 	public static class UpgradeHelper
 	{
-
 		public static void ApplyVersionChanges(ChipDescription[] customChips, ChipDescription[] builtinChips)
 		{
 			Main.Version defaultVersion = new(2, 0, 0);
@@ -47,12 +45,14 @@ namespace DLS.SaveSystem
 			Main.Version defaultModdedVersion = new(1, 0, 0);
 			Main.Version moddedVersion_1_1_0 = new(1, 1, 0); // Custom IN and OUTS version
 			Main.Version moddedVersion_1_1_1 = new(1, 1, 1); // New 16 and 32 bit pins
+			Main.Version moddedVersion_1_3_0 = new(1, 3, 0); // Setting to automatically add new chips to starred items.
 
 
 			bool canParseModdedVersion = Main.Version.TryParse(projectDescription.DLSVersion_LastSavedModdedVersion, out Main.Version projectVersion);
 
-			bool isVersionEarlierThan_1_1_0 = (!canParseModdedVersion) || projectVersion.ToInt() < moddedVersion_1_1_0.ToInt();
-			bool isVersionEarlierThan_1_1_1 = (!canParseModdedVersion) || projectVersion.ToInt() < moddedVersion_1_1_1.ToInt();
+			bool isVersionEarlierThan_1_1_0 = !canParseModdedVersion || projectVersion.ToInt() < moddedVersion_1_1_0.ToInt();
+			bool isVersionEarlierThan_1_1_1 = !canParseModdedVersion || projectVersion.ToInt() < moddedVersion_1_1_1.ToInt();
+			bool isVersionEarlierThan_1_3_0 = !canParseModdedVersion || projectVersion.ToInt() < moddedVersion_1_3_0.ToInt();
 
 			bool isSplitMergeInvalid = projectDescription.SplitMergePairs == null || projectDescription.SplitMergePairs.Count == 0;
 			bool isPinBitCountInvalid = projectDescription.pinBitCounts == null || projectDescription.pinBitCounts.Count == 0;
@@ -76,6 +76,14 @@ namespace DLS.SaveSystem
 				projectDescription.pinBitCounts.Union(Project.PinBitCounts);
 				projectDescription.SplitMergePairs.Union(Project.SplitMergePairs);
 			}
+
+			if (isVersionEarlierThan_1_3_0)
+			{
+				// Conserve original behavior (i.e. add new chips automatically to list of starred chips.)
+				projectDescription.Prefs_AddNewChipToStarredItems = true;
+				projectDescription.DLSVersion_LastSavedModdedVersion = moddedVersion_1_3_0.ToString();
+			}
+			projectDescription.DLSVersion_LastSavedModdedVersion = Main.DLSVersion_ModdedID.ToString();
         }
 
         static void UpdateChipPre_2_1_5(ChipDescription chipDesc)


### PR DESCRIPTION
Added a setting in preferences menu to allow players to disable automatically adding saved chips to starred items, so they're also not added to the bottom bar.