### PR TITLE
feature: hotkey for editing various elements

### DIFF
--- a/Assets/Scripts/Description/Types/ShortcutSettings.cs
+++ b/Assets/Scripts/Description/Types/ShortcutSettings.cs
@@ -4,6 +4,8 @@ namespace DLS.Description
 {
     public struct ShortcutSettings
     {
+	    public string LastSavedModdedVersion;
+	    
         public Shortcut MainMenu_NewProjectShortcutTriggered;
         public Shortcut MainMenu_OpenProjectShortcutTriggered;
         public Shortcut MainMenu_SettingsShortcutTriggered;
@@ -33,6 +35,9 @@ namespace DLS.Description
         public Shortcut DeleteShortcutTriggered;
         public Shortcut SimNextStepShortcutTriggered;
         public Shortcut SimPauseToggleShortcutTriggered;
+        
+        // ---- Chip interaction shortcuts ----
+        public Shortcut EditElementShortcutTriggered;
 
         // ---- Dev shortcuts ----
         public Shortcut OpenSaveDataFolderShortcutTriggered;
@@ -66,6 +71,8 @@ namespace DLS.Description
                 DeleteShortcutTriggered = new(ShortcutModifier.None, KeyCode.Backspace, alternativeKey: KeyCode.Delete),
                 SimNextStepShortcutTriggered = new(ShortcutModifier.None, KeyCode.Space, forbiddenMod: ShortcutModifier.Ctrl),
                 SimPauseToggleShortcutTriggered = new(ShortcutModifier.Ctrl, KeyCode.Space),
+                
+                EditElementShortcutTriggered = new(ShortcutModifier.None, KeyCode.E),
 
                 OpenSaveDataFolderShortcutTriggered = new(ShortcutModifier.CtrlShiftAlt, KeyCode.O),
             };

--- a/Assets/Scripts/Game/Interaction/ChipInteractionController.cs
+++ b/Assets/Scripts/Game/Interaction/ChipInteractionController.cs
@@ -223,6 +223,11 @@ namespace DLS.Game
 				}
 			}
 
+			if (KeyboardShortcuts.EditElementShortcutTriggered())
+			{
+				EditElement();
+			}
+
 			if (KeyboardShortcuts.ConfirmShortcutTriggered())
 			{
 				ExitWireEditMode();
@@ -232,8 +237,57 @@ namespace DLS.Game
 			{
 				CancelEverything();
 			}
-
         }
+
+		private void EditElement()
+		{
+			if (!CanInteract) return;
+			var elementUnderMouse = InteractionState.ElementUnderMouse;
+			switch (elementUnderMouse)
+			{
+				case PinInstance pinInstance:
+					if (pinInstance.parent is DevPinInstance devPin)
+					{
+						PinEditMenu.SetTargetPin(devPin);
+						UIDrawer.SetActiveMenu(UIDrawer.MenuType.PinRename);
+					}
+					break;
+				case DevPinInstance devPinInstance:
+						PinEditMenu.SetTargetPin(devPinInstance);
+						UIDrawer.SetActiveMenu(UIDrawer.MenuType.PinRename);
+					break;
+				case SubChipInstance subChipInstance:
+					switch (subChipInstance.ChipType)
+					{
+						case ChipType.Key:
+							RebindKeyChipMenu.SetTargetChip(subChipInstance);
+							UIDrawer.SetActiveMenu(UIDrawer.MenuType.RebindKeyChip);
+							break;
+						case ChipType.Rom_256x16:
+							RomEditMenu.SetTargetChip(subChipInstance);
+							UIDrawer.SetActiveMenu(UIDrawer.MenuType.RomEdit);
+							break;
+						case ChipType.Pulse:
+							PulseEditMenu.SetTargetChip(subChipInstance);
+							UIDrawer.SetActiveMenu(UIDrawer.MenuType.PulseEdit);
+							break;
+						case ChipType.Constant_8Bit:
+							ConstantEditMenu.SetTargetChip(subChipInstance);
+							UIDrawer.SetActiveMenu(UIDrawer.MenuType.ConstantEdit);
+							break;
+						default:
+							ChipLabelMenu.SetTargetChip(subChipInstance);
+							UIDrawer.SetActiveMenu(UIDrawer.MenuType.ChipLabelPopup);
+							break;
+					}
+					break;
+				case WireInstance wireInstance:
+					Project.ActiveProject.controller.EnterWireEditMode(wireInstance);
+					break;
+				
+				// Simply ignore pressed hotkey in other cases.
+			}
+		}
 
 		void HandleMouseInput()
 		{
@@ -569,7 +623,7 @@ namespace DLS.Game
 					return;
 				}
 
-				hasMoved |= (element.MoveStartPosition != element.Position);
+				hasMoved |= element.MoveStartPosition != element.Position;
 			}
 
 			if (hasMoved) ActiveDevChip.UndoController.RecordMoveElements(SelectedElements);

--- a/Assets/Scripts/Game/Interaction/KeyboardShortcuts.cs
+++ b/Assets/Scripts/Game/Interaction/KeyboardShortcuts.cs
@@ -37,6 +37,9 @@ namespace DLS.Game
 		public static Func<bool> DeleteShortcutTriggered;
 		public static Func<bool> SimNextStepShortcutTriggered;
 		public static Func<bool> SimPauseToggleShortcutTriggered;
+		
+		// ---- Chip interaction shortcuts ----
+		public static Func<bool> EditElementShortcutTriggered;
 
 		// ---- Dev shortcuts ----
 		public static Func<bool> OpenSaveDataFolderShortcutTriggered;
@@ -53,7 +56,7 @@ namespace DLS.Game
 
 		// ---- Helpers ----
 		public static bool CtrlShortcutTriggered(KeyCode key) => InputHelper.IsKeyDownThisFrame(key) && InputHelper.CtrlIsHeld && !(InputHelper.AltIsHeld || InputHelper.ShiftIsHeld);
-        public static bool CtrlShiftShortcutTriggered(KeyCode key) => InputHelper.IsKeyDownThisFrame(key) && InputHelper.CtrlIsHeld && InputHelper.ShiftIsHeld && !(InputHelper.AltIsHeld);
+        public static bool CtrlShiftShortcutTriggered(KeyCode key) => InputHelper.IsKeyDownThisFrame(key) && InputHelper.CtrlIsHeld && InputHelper.ShiftIsHeld && !InputHelper.AltIsHeld;
         public static bool ShiftShortcutTriggered(KeyCode key) => InputHelper.IsKeyDownThisFrame(key) && InputHelper.ShiftIsHeld && !(InputHelper.AltIsHeld || InputHelper.CtrlIsHeld);
 		public static bool AltShortcutTriggered(KeyCode key) => InputHelper.IsKeyDownThisFrame(key) && InputHelper.AltIsHeld && !(InputHelper.CtrlIsHeld || InputHelper.ShiftIsHeld);
 		public static bool CtrlShiftAltShortcutTriggered(KeyCode key) => InputHelper.IsKeyDownThisFrame(key) && InputHelper.CtrlIsHeld && InputHelper.AltIsHeld && InputHelper.ShiftIsHeld;
@@ -90,23 +93,35 @@ namespace DLS.Game
             LoadShortcut(out SimPauseToggleShortcutTriggered, shortcutSettings.SimPauseToggleShortcutTriggered);
 
             LoadShortcut(out OpenSaveDataFolderShortcutTriggered, shortcutSettings.OpenSaveDataFolderShortcutTriggered);
+            
+            LoadShortcut(out EditElementShortcutTriggered, shortcutSettings.EditElementShortcutTriggered, InputState.Up);
         }
 
-        public static void LoadShortcut(out Func<bool> shortcutFunction, Shortcut shortcut)
+        public static void LoadShortcut(out Func<bool> shortcutFunction, Shortcut shortcut, InputState inputState = InputState.Down)
 		{
 			shortcutFunction = () => false;
 			if (shortcut.ForbiddenModifier == ShortcutModifier.None && shortcut.AlternativeKeyCode == KeyCode.None && shortcut.AlternativeModifier == ShortcutModifier.None)
 			{
-				LoadSimpleShortcut(out shortcutFunction, shortcut);
+				LoadSimpleShortcut(out shortcutFunction, shortcut, inputState);
 				return;
 			}
 
 			LoadComplexShortcut(out shortcutFunction, shortcut);
 		}
 
-		static void LoadSimpleShortcut(out Func<bool> shortcutFunction, Shortcut shortcut)
+		static void LoadSimpleShortcut(out Func<bool> shortcutFunction, Shortcut shortcut, InputState inputState)
 		{
-			shortcutFunction = () => GetFuncFromShortcutModifier(shortcut.Modifier)() && InputHelper.IsKeyDownThisFrame(shortcut.KeyCode);
+			shortcutFunction = () =>
+			{
+				bool triggered = inputState switch
+				{
+					InputState.Down => InputHelper.IsKeyDownThisFrame(shortcut.KeyCode),
+					InputState.Held => InputHelper.IsKeyHeld(shortcut.KeyCode),
+					InputState.Up => InputHelper.IsKeyUpThisFrame(shortcut.KeyCode),
+					_ => throw new ArgumentOutOfRangeException(nameof(inputState), inputState, "Loading shortcut triggered in this state is not implemented.")
+				};
+				return GetFuncFromShortcutModifier(shortcut.Modifier)() && triggered;
+			};
 		}
 
 		static void LoadComplexShortcut(out Func<bool> shortcutFunction, Shortcut shortcut)

--- a/Assets/Scripts/Graphics/UI/Menus/ChipLabelMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ChipLabelMenu.cs
@@ -19,10 +19,13 @@ namespace DLS.Graphics
 
 		static readonly bool[] ButtonGroupInteractStates = { true, true };
 
+		public static void SetTargetChip(SubChipInstance chip)
+		{
+			subChip = chip;
+		}
+
 		public static void OnMenuOpened()
 		{
-			subChip = (SubChipInstance)ContextMenu.interactionContext;
-
 			InputFieldState inputFieldState = UI.GetInputFieldState(ID_NameField);
 			inputFieldState.SetText(subChip.Label);
 			inputFieldState.SelectAll();

--- a/Assets/Scripts/Graphics/UI/Menus/ConstantEditMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ConstantEditMenu.cs
@@ -53,16 +53,19 @@ namespace DLS.Graphics
 			}
 		}
 
+		public static void SetTargetChip(SubChipInstance chip)
+		{
+			constantChip = chip;
+		}
+
 		public static void OnMenuOpened()
 		{
-			constantChip = (SubChipInstance)ContextMenu.interactionContext;
 			value = (byte)constantChip.InternalData[0];
 			UI.GetInputFieldState(ID_ValueInput).SetText(value.ToString());
 		}
 
 		public static bool ValidateValueInput(string s)
 		{
-			Debug.Log(s);
 			if (s.Length > 4) return false;
 			if (string.IsNullOrEmpty(s)) return true;
 			if (s.Contains(" ")) return false;

--- a/Assets/Scripts/Graphics/UI/Menus/ContextMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ContextMenu.cs
@@ -391,6 +391,7 @@ namespace DLS.Graphics
 
 		static void OpenChipLabelPopup()
 		{
+			ChipLabelMenu.SetTargetChip(interactionContext as SubChipInstance);
 			UIDrawer.SetActiveMenu(UIDrawer.MenuType.ChipLabelPopup);
 		}
 
@@ -417,14 +418,27 @@ namespace DLS.Graphics
 
 		static void OpenKeyBindMenu()
 		{
+			RebindKeyChipMenu.SetTargetChip((SubChipInstance)interactionContext);
 			UIDrawer.SetActiveMenu(UIDrawer.MenuType.RebindKeyChip);
 		}
 
-		static void OpenRomEditMenu() => UIDrawer.SetActiveMenu(UIDrawer.MenuType.RomEdit);
+		static void OpenRomEditMenu()
+		{
+			RomEditMenu.SetTargetChip((SubChipInstance)interactionContext);
+			UIDrawer.SetActiveMenu(UIDrawer.MenuType.RomEdit);
+		}
 
-		static void OpenPulseEditMenu() => UIDrawer.SetActiveMenu(UIDrawer.MenuType.PulseEdit);
+		static void OpenPulseEditMenu()
+		{
+			PulseEditMenu.SetTargetChip((SubChipInstance)interactionContext);
+			UIDrawer.SetActiveMenu(UIDrawer.MenuType.PulseEdit);
+		}
 
-		static void OpenConstantEditMenu() => UIDrawer.SetActiveMenu(UIDrawer.MenuType.ConstantEdit);
+		static void OpenConstantEditMenu()
+		{
+			ConstantEditMenu.SetTargetChip((SubChipInstance)interactionContext);
+			UIDrawer.SetActiveMenu(UIDrawer.MenuType.ConstantEdit);
+		}
 
 		static bool CanEditCurrentChip() => Project.ActiveProject.CanEditViewedChip;
 
@@ -468,6 +482,7 @@ namespace DLS.Graphics
 
 		public static void CloseContextMenu()
 		{
+			interactionContext = null;
 			IsOpen = false;
 		}
 

--- a/Assets/Scripts/Graphics/UI/Menus/ControlsScreen.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ControlsScreen.cs
@@ -30,6 +30,7 @@ namespace DLS.Graphics
             { "Duplicate Selection", Main.ActiveShortcutSettings.DuplicateShortcutTriggered },
             { "Toggle Grid", Main.ActiveShortcutSettings.ToggleGridShortcutTriggered },
             { "Reset Camera", Main.ActiveShortcutSettings.ResetCameraShortcutTriggered },
+            { "Edit Element", Main.ActiveShortcutSettings.EditElementShortcutTriggered },
             { "Undo", Main.ActiveShortcutSettings.UndoShortcutTriggered },
             { "Redo", Main.ActiveShortcutSettings.RedoShortcutTriggered },
             { "Lock Mode", Main.ActiveShortcutSettings.LockModeShortcutTriggered },

--- a/Assets/Scripts/Graphics/UI/Menus/PulseEditMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/PulseEditMenu.cs
@@ -50,9 +50,13 @@ namespace DLS.Graphics
 			}
 		}
 
+		public static void SetTargetChip(SubChipInstance chip)
+		{
+			pulseChip = chip;
+		}
+
 		public static void OnMenuOpened()
 		{
-			pulseChip = (SubChipInstance)ContextMenu.interactionContext;
 			pulseWidth = pulseChip.InternalData[0];
 			UI.GetInputFieldState(ID_PulseWidthInput).SetText(pulseWidth.ToString());
 		}

--- a/Assets/Scripts/Graphics/UI/Menus/RebindKeyChipMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/RebindKeyChipMenu.cs
@@ -97,11 +97,14 @@ namespace DLS.Graphics
 				}
 			}
 		}
-		
+
+		public static void SetTargetChip(SubChipInstance chip)
+		{
+			keyChip = chip;
+		}
+
 		public static void OnMenuOpened()
 		{
-			keyChip = (SubChipInstance)ContextMenu.interactionContext;
-
 			chosenKey = (KeyCode)keyChip.InternalData[0];
 		}
 	}

--- a/Assets/Scripts/Graphics/UI/Menus/RomEditMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/RomEditMenu.cs
@@ -336,10 +336,14 @@ namespace DLS.Graphics
 			// Set bounding box of scroll list element 
 			UI.OverridePreviousBounds(entryBounds);
 		}
+		
+		public static void SetTargetChip(SubChipInstance chip)
+		{
+			romChip = chip;
+		}
 
 		public static void OnMenuOpened()
 		{
-			romChip = (SubChipInstance)ContextMenu.interactionContext;
 			RowCount = romChip.InternalData.Length;
 			ActiveRomDataBitCount = 16; //
 

--- a/Assets/Scripts/SaveSystem/Loader.cs
+++ b/Assets/Scripts/SaveSystem/Loader.cs
@@ -27,7 +27,9 @@ namespace DLS.SaveSystem
 			if(File.Exists(SavePaths.ShortcutSettingsPath))
 			{
 				string shortcutsString = File.ReadAllText (SavePaths.ShortcutSettingsPath);
-				return Serializer.DeserializeShortcutSettings(shortcutsString);
+				ShortcutSettings shortcutSettings = Serializer.DeserializeShortcutSettings(shortcutsString);
+				UpgradeHelper.ApplyVersionChangesToShortcuts(ref shortcutSettings);
+				return shortcutSettings;
 			}
 			return ShortcutSettings.Default();
 		}

--- a/Assets/Scripts/SaveSystem/UpgradeHelper.cs
+++ b/Assets/Scripts/SaveSystem/UpgradeHelper.cs
@@ -8,7 +8,6 @@ namespace DLS.SaveSystem
 {
 	public static class UpgradeHelper
 	{
-
 		public static void ApplyVersionChanges(ChipDescription[] customChips, ChipDescription[] builtinChips)
 		{
 			Main.Version defaultVersion = new(2, 0, 0);
@@ -121,6 +120,29 @@ namespace DLS.SaveSystem
 		{
 			// ---- Fixed Caching ----
 			SavedDescriptionCachingCorrector.CorrectCachingAbility(chipDesc);
+		}
+
+		public static void ApplyVersionChangesToShortcuts(ref ShortcutSettings shortcutSettings)
+		{
+			Main.Version defaultModdedVersion = new(1, 2, 1);
+			Main.Version moddedVersion_1_3_0 = new(1, 3, 0); // Edit elements hotkey
+
+			if (!Main.Version.TryParse(shortcutSettings.LastSavedModdedVersion, out Main.Version moddedVersion))
+			{
+				moddedVersion = defaultModdedVersion;
+			}
+			
+			if (moddedVersion.ToInt() < moddedVersion_1_3_0.ToInt())
+			{
+				UpdateShortcutSettingsPreModded_1_3_0(ref shortcutSettings);
+				shortcutSettings.LastSavedModdedVersion = moddedVersion_1_3_0.ToString();
+			}
+		}
+
+		private static void UpdateShortcutSettingsPreModded_1_3_0(ref ShortcutSettings shortcutSettings)
+		{
+			var defaults = ShortcutSettings.Default();
+			shortcutSettings.EditElementShortcutTriggered = defaults.EditElementShortcutTriggered;
 		}
 	}
 }

--- a/Assets/Scripts/Seb/Helpers/Input/InputHelper.cs
+++ b/Assets/Scripts/Seb/Helpers/Input/InputHelper.cs
@@ -13,6 +13,13 @@ namespace Seb.Helpers
 		Middle = 2
 	}
 
+	public enum InputState
+	{
+		Down,
+		Held,
+		Up
+	}
+
 	public static class InputHelper
 	{
 		public static IInputSource InputSource = new UnityInputSource();


### PR DESCRIPTION
- default hotkey is e, rebindable in controls menu
- when mouse is hovering over an interactable element and the hotkey is pressed, an "edit action" will be invoked, depending on the type of interactable:
    - If it's a wire, edit mode will be started
    - DevPin: Open menu to rename
    - KeyChip, ROM, Pulse and Constant open their respective edit menus
    - Other subchips will be labeled