### PR TITLE
Refactor subchip name

### DIFF
--- a/Assets/Scripts/Game/Elements/SubChipInstance.cs
+++ b/Assets/Scripts/Game/Elements/SubChipInstance.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using DLS.Description;
 using DLS.Graphics;
 using DLS.SaveSystem;
 using Seb.Helpers;
 using Seb.Types;
-using Seb.Vis;
 using UnityEngine;
 using Exception = System.Exception;
 
@@ -28,7 +26,12 @@ namespace DLS.Game
 		public Vector2 MinSize;
 		public Vector2 InstanceSize;
 
-		public string MultiLineName;
+		/// Name displayed on every SubChip, if not hidden.
+		/// <remarks>
+		/// <para> - Long names with spaces will be wrapped. </para>
+		/// <para> - KeyChips will show their ActivationChar instead. </para>
+		/// </remarks>
+		public string DisplayName;
 		public readonly PinInstance[] OutputPins;
 		public string Label;
 		public bool HasCustomLayout;
@@ -42,9 +45,9 @@ namespace DLS.Game
 			ID = subChipDesc.ID;
 			Label = subChipDesc.Label;
 			IsBus = ChipTypeHelper.IsBusType(ChipType);
-			MultiLineName = CreateMultiLineName(description.Name);
 			MinSize = CalculateMinChipSize(description.InputPins, description.OutputPins, description.Name);
 			InstanceSize = MinSize;
+			DisplayName = SubChipHelper.GetDisplayName(description.Name, InstanceSize);
 
 			HasCustomLayout = description.HasCustomLayout;
 
@@ -148,6 +151,8 @@ namespace DLS.Game
 
 			// Update size so it changes
 			updateMinSize();
+			
+			DisplayName = InputHelper.UintToKeyName(InternalData[0]);
 		}
 
 		public void UpdatePinLayout()
@@ -316,7 +321,7 @@ namespace DLS.Game
 			MinX = Mathf.Abs(MinX) * DrawSettings.GridSize;
             MinY = Mathf.Abs(MinY) * DrawSettings.GridSize;
             
-            string multiLineName = CreateMultiLineName(Description.Name);
+            string multiLineName = SubChipHelper.CreateMultiLineName(Description.Name);
             bool hasMultiLineName = multiLineName != Description.Name;
             float minNameHeight = DrawSettings.GridSize * (hasMultiLineName ? 4 : 3);
 
@@ -459,7 +464,7 @@ namespace DLS.Game
 		public static Vector2 CalculateMinChipSize(PinDescription[] inputPins, PinDescription[] outputPins, string unformattedName)
 		{
 			float minHeightForPins = MinChipHeightForPins(inputPins, outputPins);
-			string multiLineName = CreateMultiLineName(unformattedName);
+			string multiLineName = SubChipHelper.CreateMultiLineName(unformattedName);
 			bool hasMultiLineName = multiLineName != unformattedName;
 			float minNameHeight = DrawSettings.GridSize * (hasMultiLineName ? 4 : 3);
 
@@ -486,58 +491,6 @@ namespace DLS.Game
 		public static float GetPinDepthMultiplier(PinBitCount bitCount)
 		{
 			return (float)Math.Pow(8, -bitCount.GetTier());
-		}
-
-		// Split chip name into two lines (if contains a space character)
-		static string CreateMultiLineName(string name)
-		{
-			// If name is short, or contains no spaces, then just keep on single line
-			if (name.Length <= 6 || !name.Contains(' ')) return name;
-
-			string[] lines = { name };
-			float bestSplitPenalty = float.MaxValue;
-
-			for (int i = 0; i < name.Length; i++)
-			{
-				if (name[i] == ' ')
-				{
-					string lineA = name.Substring(0, i).Trim();
-					string lineB = name.Substring(i).Trim();
-					int lenDiff = lineA.Length - lineB.Length;
-					float splitPenalty = Mathf.Abs(lenDiff);
-					if (splitPenalty < bestSplitPenalty)
-					{
-						lines = new[] { lineA, lineB };
-						bestSplitPenalty = splitPenalty;
-					}
-				}
-			}
-
-
-			// Pad lines with spaces to centre justify
-			string formatted = "";
-			int longestLine = lines.Max(l => l.Length);
-
-			for (int i = 0; i < lines.Length; i++)
-			{
-				string line = lines[i];
-				int numPadChars = longestLine - line.Length;
-				int numPadLeft = numPadChars / 2;
-				int numPadRight = numPadChars - numPadLeft;
-				line = line.PadLeft(line.Length + numPadLeft, ' ');
-				line = line.PadRight(line.Length + numPadRight, ' ');
-
-				// Add half space tag to center if padding is uneven
-				if (numPadLeft < numPadRight)
-				{
-					line = "<halfSpace>" + line;
-				}
-
-				formatted += line;
-				if (i < lines.Length - 1) formatted += "\n";
-			}
-
-			return formatted;
 		}
 
 		public void FlipBus()

--- a/Assets/Scripts/Game/Helpers/SubChipHelper.cs
+++ b/Assets/Scripts/Game/Helpers/SubChipHelper.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Seb.Vis;
+using UnityEngine;
+using static DLS.Graphics.DrawSettings;
+
+namespace DLS.Game
+{
+	public static class SubChipHelper
+	{
+		/// Display on single line if name fits comfortably, otherwise use 'formatted' version (split across multiple lines)
+		[Pure]
+		public static string GetDisplayName(string name, Vector2 size)
+		{
+			if (Draw.CalculateTextBoundsSize(name, FontSizeChipName, FontBold).x < size.x - PinRadius * 2.5f)
+			{
+				return name;
+			}
+			return CreateMultiLineName(name);
+		}
+
+		/// <summary>
+		/// Split name into two lines if necessary.
+		/// </summary>
+		/// <param name="name"> Unformatted name of the chip </param>
+		/// <remarks>
+		/// If <paramref name="name"/> is shorter than 7 characters or contains no spaces, unformatted name will be returned.
+		/// </remarks>
+		[Pure]
+		public static string CreateMultiLineName(string name)
+		{
+			if (name.Length <= 6 || !name.Contains(' ')) return name;
+
+			string[] lines = { name };
+			float bestSplitPenalty = float.MaxValue;
+
+			for (int i = 0; i < name.Length; i++)
+			{
+				if (name[i] == ' ')
+				{
+					string lineA = name.Substring(0, i).Trim();
+					string lineB = name.Substring(i).Trim();
+					int lenDiff = lineA.Length - lineB.Length;
+					float splitPenalty = Mathf.Abs(lenDiff);
+					if (splitPenalty < bestSplitPenalty)
+					{
+						lines = new[] { lineA, lineB };
+						bestSplitPenalty = splitPenalty;
+					}
+				}
+			}
+
+			// Pad lines with spaces to centre justify
+			string formatted = "";
+			int longestLine = lines.Max(l => l.Length);
+
+			for (int i = 0; i < lines.Length; i++)
+			{
+				string line = lines[i];
+				int numPadChars = longestLine - line.Length;
+				int numPadLeft = numPadChars / 2;
+				int numPadRight = numPadChars - numPadLeft;
+				line = line.PadLeft(line.Length + numPadLeft, ' ');
+				line = line.PadRight(line.Length + numPadRight, ' ');
+
+				// Add half space tag to center if padding is uneven
+				if (numPadLeft < numPadRight)
+				{
+					line = "<halfSpace>" + line;
+				}
+
+				formatted += line;
+				if (i < lines.Length - 1) formatted += "\n";
+			}
+
+			return formatted;
+		}
+	}
+}

--- a/Assets/Scripts/Game/Helpers/SubChipHelper.cs.meta
+++ b/Assets/Scripts/Game/Helpers/SubChipHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2dffe544b67147cc896d028051ece276
+timeCreated: 1776268109

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -329,25 +329,23 @@ namespace DLS.Graphics
 			// Draw name
 			if (isKeyChip || desc.NameLocation != NameDisplayLocation.Hidden)
 			{
-				string displayName = subchip.DisplayName;
-				bool nameCentre = desc.NameLocation == NameDisplayLocation.Centre || isKeyChip;
-				Anchor textAnchor = nameCentre ? Anchor.TextCentre : Anchor.CentreTop;
-				Vector2 textPos = nameCentre ? pos : pos + Vector2.up * (subchip.Size.y / 2 - GridSize / 2);
-
 				// Draw background band behind text if placed at top (so it doesn't look out of place..)
 				if (desc.NameLocation == NameDisplayLocation.Top)
 				{
 					Color bgBandCol = GetChipDisplayBorderCol(chipCol);
 					Vector2 topLeft = pos + new Vector2(-desc.Size.x / 2, desc.Size.y / 2);
-					TextRenderer.BoundingBox textBounds = Draw.CalculateTextBounds(displayName, FontBold, FontSizeChipName, textPos, textAnchor);
+					Vector2 textPos = pos + Vector2.up * (subchip.Size.y / 2 - GridSize / 2);
+					TextRenderer.BoundingBox textBounds = Draw.CalculateTextBounds(subchip.DisplayName, FontBold, FontSizeChipName, textPos, Anchor.CentreTop);
 					float h = (topLeft.y - textBounds.Centre.y) * 2;
 
 					Vector2 s = new(desc.Size.x, h);
 					Vector2 c = topLeft + new Vector2(s.x, -s.y) / 2;
 					Draw.Quad(c, s, bgBandCol);
+					Draw.Text(FontBold, subchip.DisplayName, FontSizeChipName, textPos, Anchor.CentreTop, nameTextCol, ChipNameLineSpacing);
+					return;
 				}
 
-				Draw.Text(FontBold, displayName, FontSizeChipName, textPos, textAnchor, nameTextCol, ChipNameLineSpacing);
+				Draw.Text(FontBold, subchip.DisplayName, FontSizeChipName, pos, Anchor.TextCentre, nameTextCol, ChipNameLineSpacing);
 			}
 		}
 

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -313,11 +313,12 @@ namespace DLS.Graphics
 
 
 			// Draw outline and body
-			Draw.Quad(pos, subchip.Size + Vector2.one * ChipOutlineWidth, outlineCol);
-			Draw.Quad(pos, subchip.Size, chipCol);
+			Vector2 size = subchip.Size;
+			Draw.Quad(pos, size + Vector2.one * ChipOutlineWidth, outlineCol);
+			Draw.Quad(pos, size, chipCol);
 
 			// Mouse over detection
-			if (InputHelper.MouseInsideBounds_World(pos, subchip.Size))
+			if (InputHelper.MouseInsideBounds_World(pos, size))
 			{
 				// If mouse is over one of this chip's pins, then prioritize keeping the pin highlighted (so interaction is not too fiddly)
 				if (InteractionState.PinUnderMouse == null || InteractionState.PinUnderMouse.parent != subchip)
@@ -333,12 +334,13 @@ namespace DLS.Graphics
 				if (desc.NameLocation == NameDisplayLocation.Top)
 				{
 					Color bgBandCol = GetChipDisplayBorderCol(chipCol);
-					Vector2 topLeft = pos + new Vector2(-desc.Size.x / 2, desc.Size.y / 2);
-					Vector2 textPos = pos + Vector2.up * (subchip.Size.y / 2 - GridSize / 2);
+					float halfHeight = size.y / 2;
+					Vector2 topLeft = pos + new Vector2(-size.x / 2, halfHeight);
+					Vector2 textPos = pos + Vector2.up * (halfHeight - GridSize / 2);
 					TextRenderer.BoundingBox textBounds = Draw.CalculateTextBounds(subchip.DisplayName, FontBold, FontSizeChipName, textPos, Anchor.CentreTop);
 					float h = (topLeft.y - textBounds.Centre.y) * 2;
 
-					Vector2 s = new(desc.Size.x, h);
+					Vector2 s = new(size.x, h);
 					Vector2 c = topLeft + new Vector2(s.x, -s.y) / 2;
 					Draw.Quad(c, s, bgBandCol);
 					Draw.Text(FontBold, subchip.DisplayName, FontSizeChipName, textPos, Anchor.CentreTop, nameTextCol, ChipNameLineSpacing);

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -329,14 +329,7 @@ namespace DLS.Graphics
 			// Draw name
 			if (isKeyChip || desc.NameLocation != NameDisplayLocation.Hidden)
 			{
-				// Display on single line if name fits comfortably, otherwise use 'formatted' version (split across multiple lines)
-				string displayName = isKeyChip ? InputHelper.UintToKeyName(subchip.InternalData[0]) : subchip.MultiLineName;
-				string nameToCheckFit = isKeyChip ? InputHelper.UintToKeyName(subchip.InternalData[0]) : subchip.Description.Name;
-				if (Draw.CalculateTextBoundsSize(nameToCheckFit, FontSizeChipName, FontBold).x < subchip.Size.x - PinRadius * 2.5f)
-				{
-					displayName = nameToCheckFit;
-				}
-
+				string displayName = subchip.DisplayName;
 				bool nameCentre = desc.NameLocation == NameDisplayLocation.Centre || isKeyChip;
 				Anchor textAnchor = nameCentre ? Anchor.TextCentre : Anchor.CentreTop;
 				Vector2 textPos = nameCentre ? pos : pos + Vector2.up * (subchip.Size.y / 2 - GridSize / 2);


### PR DESCRIPTION
SubChips now have a field to hold the name which will be displayed to players, instead of the multiLine name.
This saves saves some expensive recalculation of textbounds every frame while rendering.

KeyChips will store their activation char there, for the same reason.
Also made use of the fact that there are only a couple of options for the name location to reduce branching when drawing names.
Also used subchip.size in calculations, not description.size in a few cases, to hopefully save some fetches.

SubChips with their name displayed at the top of a chip still do a similar calculation once, to get the height of the text, but the performance overall should be improved a bit.

<img width="1913" height="1027" alt="image" src="https://github.com/user-attachments/assets/d9fc7a44-116f-4b76-bcff-e0a93874792e" />

